### PR TITLE
Improve IIS support

### DIFF
--- a/roles/software_discovery/defaults/main.yml
+++ b/roles/software_discovery/defaults/main.yml
@@ -52,7 +52,7 @@ software_discovery__software_list:
           file: "{{ software_discovery__custom_tasks_definition_files_path }}/sql_server.yaml"
 
   - name: IIS
-    cmd_regexp: 'w3wp.exe'  # Service iissvcs
+    cmd_regexp: 'iissvcs'
     process_type: single
     return_children: false
     return_packages: false

--- a/roles/software_discovery/files/tasks_definitions/iis.yaml
+++ b/roles/software_discovery/files/tasks_definitions/iis.yaml
@@ -29,31 +29,74 @@
         - name: Format data
           set_instance_fact:
             _entry: "<< __item__ | from_json >>"
-        - name: Split binding information
-          set_instance_fact:
-            _entry_binding: "<< __instance__._entry.bindings.replace('*:', '0.0.0.0:').split(':') >>"
-        - name: Add binding information
-          add_binding_info:
-            address: "<< __instance__._entry_binding[0] >>"
-            port: "<< __instance__._entry_binding[1] >>"
-            protocol: "tcp"
-        - name: Add endpoint information when site is defined
-          add_endpoint_info:
-            uri: "<< __instance__._entry.protocol + '://' + __instance__._entry_binding[2] + ':' + __instance__._entry_binding[1] >>"
-            extra_data:
-              name: "<< __instance__._entry.name >>"
-              path: "<< __instance__._entry.physical_path >>"
-          when: __instance__._entry_binding[2]
-        - name: Add endpoint information when site is not defined
-          add_endpoint_info:
-            uri: "<< __instance__._entry.protocol + '://' + __instance__._entry_binding[0] + ':' + __instance__._entry_binding[1] >>"
-            extra_data:
-              name: "<< __instance__._entry.name >>"
-              path: "<< __instance__._entry.physical_path >>"
-          when: not __instance__._entry_binding[2]
-        - name: Add port to listening_ports
-          set_instance_fact:
-            listening_ports: "<< (__instance__.listening_ports + [__instance__._entry_binding[1] | int]) | unique >>"
+        - name: Process entries with http or https protocols
+          block:
+            - name: Split binding information
+              set_instance_fact:
+                _entry_binding: "<< __instance__._entry.bindings.replace(' ', '').replace('*:', '0.0.0.0:').split(':') >>"
+            - name: Add binding information
+              add_binding_info:
+                address: "<< __instance__._entry_binding[0] >>"
+                port: "<< __instance__._entry_binding[1] >>"
+                protocol: "<< __instance__._entry.protocol >>"
+            - name: Add endpoint information when site is defined
+              add_endpoint_info:
+                uri: "<< __instance__._entry.protocol + '://' + __instance__._entry_binding[2] + ':' + __instance__._entry_binding[1] >>"
+                extra_data:
+                  name: "<< __instance__._entry.name >>"
+                  path: "<< __instance__._entry.physical_path >>"
+              when: __instance__._entry_binding[2]
+            - name: Add endpoint information when site is not defined
+              add_endpoint_info:
+                uri: "<< __instance__._entry.protocol + '://' + __instance__._entry_binding[0] + ':' + __instance__._entry_binding[1] >>"
+                extra_data:
+                  name: "<< __instance__._entry.name >>"
+                  path: "<< __instance__._entry.physical_path >>"
+              when: not __instance__._entry_binding[2]
+            - name: Add port to listening_ports
+              set_instance_fact:
+                listening_ports: "<< (__instance__.listening_ports + [__instance__._entry_binding[1] | int]) | unique >>"
+          when: __instance__._entry.protocol == 'http' or __instance__._entry.protocol == 'https'
+        - name: Process entries with net.tcp protocol
+          block:
+            - name: Split binding information
+              set_instance_fact:
+                _entry_binding: "<< __instance__._entry.bindings.replace(' ', '').replace(':*', ':0.0.0.0').split(':') >>"
+            - name: Add binding information
+              add_binding_info:
+                port: "<< __instance__._entry_binding[0] >>"
+                protocol: "<< __instance__._entry.protocol >>"
+            - name: Add endpoint information
+              add_endpoint_info:
+                uri: "<<  __instance__._entry.protocol + '://' + __instance__._entry_binding[1] + ':' + __instance__._entry_binding[0] >>"
+                extra_data:
+                  name: "<< __instance__._entry.name >>"
+                  path: "<< __instance__._entry.physical_path >>"
+            - name: Add port to listening_ports
+              set_instance_fact:
+                listening_ports: "<< (__instance__.listening_ports + [__instance__._entry_binding[0] | int]) | unique >>"
+          when: __instance__._entry.protocol == 'net.tcp'
+        - name: Process entires with net.msmq protocol
+          block:
+            - name: Split binding information
+              set_instance_fact:
+                _entry_binding: "<< __instance__._entry.bindings.replace(' ', '').replace('*', '0.0.0.0') >>"
+            - name: Add binding information
+              add_binding_info:
+                port: "1801"
+                protocol: "<< __instance__._entry.protocol >>"
+            - name: Add endpoint information
+              add_endpoint_info:
+                uri: "<<   __instance__._entry.protocol + '://' +  __instance__._entry_binding >>"
+                extra_data:
+                  name: "<< __instance__._entry.name >>"
+                  path: "<< __instance__._entry.physical_path >>"
+            - name: Add port to listening_ports
+              set_instance_fact:
+                listening_ports: "<< (__instance__.listening_ports + [1801]) | unique >>"
+          when: __instance__._entry.protocol == 'net.msmq'
+        # net.pipe protocol is ignored since it is only used locally for communication purposes
+        # msmq.formatname protocol is ignored since is only a queue for the same binding that uses net.msmq
       loop: "<< result.stdout_lines | default([]) >>"
 
 - name: Remove tmp vars

--- a/tests/unit/plugins/action/auto/resources/iis/windows_server_2012_r2_iis_8.5.yaml
+++ b/tests/unit/plugins/action/auto/resources/iis/windows_server_2012_r2_iis_8.5.yaml
@@ -11,6 +11,10 @@ mocked_plugin_tasks:
       failed: false
       stdout_lines:
         - "{\"name\":\"Default Web Site\",\"protocol\":\"http\",\"bindings\":\"*:80:\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
+        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.tcp\",\"bindings\":\"808:*\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
+        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.msmq\",\"bindings\":\"localhost\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
+        - "{\"name\":\"Default Web Site\",\"protocol\":\"msmq.formatname\",\"bindings\":\"localhost\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
+        - "{\"name\":\"Default Web Site\",\"protocol\":\"net.pipe\",\"bindings\":\"*\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
         - "{\"name\":\"Default Web Site\",\"protocol\":\"https\",\"bindings\":\"*:443:\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
         - "{\"name\":\"Extra Web Site\",\"protocol\":\"http\",\"bindings\":\"*:800:demo.iometrics.io\",\"physical_path\":\"%SystemDrive%\\\\inetpub\\\\wwwroot\"}"
 
@@ -42,6 +46,16 @@ expected_result:
           name: Default Web Site
           path: "%SystemDrive%\\inetpub\\wwwroot"
         type: generic
+        uri: net.tcp://0.0.0.0:808
+      - extra_data:
+          name: Default Web Site
+          path: "%SystemDrive%\\inetpub\\wwwroot"
+        type: generic
+        uri: net.msmq://localhost
+      - extra_data:
+          name: Default Web Site
+          path: "%SystemDrive%\\inetpub\\wwwroot"
+        type: generic
         uri: https://0.0.0.0:443
       - extra_data:
           name: Extra Web Site
@@ -49,20 +63,28 @@ expected_result:
         type: generic
         uri: http://demo.iometrics.io:800
     bindings:
-      - address: "0.0.0.0"
+      - address: 0.0.0.0
         class: service
         port: 80
-        protocol: tcp
-      - address: "0.0.0.0"
+        protocol: http
+      - class: service
+        port: 808
+        protocol: net.tcp
+      - class: service
+        port: 1801
+        protocol: net.msmq
+      - address: 0.0.0.0
         class: service
         port: 443
-        protocol: tcp
-      - address: "0.0.0.0"
+        protocol: https
+      - address: 0.0.0.0
         class: service
         port: 800
-        protocol: tcp
+        protocol: http
     listening_ports:
       - 80
+      - 808
+      - 1801
       - 443
       - 800
     process:


### PR DESCRIPTION
Improve IIS support by adding the following additional protocols:
- net.tcp
- net.msmq

Also, IIS regex has been switched from `w3wp.exe` to `iissvcs`, since `iissvcs` may have multiple `w3wp.exe` as childs.