### PR TITLE
Fix Apache Webserver regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.1
+
+## Fixes
+- Fixed a problem with the Apache Webserver regex
+
 # 1.0.0
 
 Initial version of `datadope.discovery` Ansible collection.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.0
+version: 1.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/file_parser.py
+++ b/plugins/modules/file_parser.py
@@ -36,10 +36,12 @@ options:
     description: Environment variables that will be injected into the parser.
     required: false
     type: dict
+    default: {}
   path_prefix:
     description: Prefix that will be appended to every path that the parser will access during its operation.
     required: false
     type: str
+    default: ''
   strict_vars:
     description: Determines if the process should fail if a defined environment variable is not available.
     required: false

--- a/roles/software_discovery/defaults/main.yml
+++ b/roles/software_discovery/defaults/main.yml
@@ -62,7 +62,7 @@ software_discovery__software_list:
           file: "{{ software_discovery__custom_tasks_definition_files_path }}/iis.yaml"
 
   - name: Apache WebServer
-    cmd_regexp: "^.*\/(?:sbin|bin)\/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?"
+    cmd_regexp: "^.*/(?:sbin|bin)/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?"
     pkg_regexp: 'apache2|^httpd$'
     process_type: parent
     return_children: true

--- a/tests/unit/plugins/action/auto/resources/apache_webserver/apache2.4.6_centos7.6.yaml
+++ b/tests/unit/plugins/action/auto/resources/apache_webserver/apache2.4.6_centos7.6.yaml
@@ -418,7 +418,7 @@ expected_result:
         type: package
 
 software_list:
-  - cmd_regexp: "^.*\/(?:sbin|bin)\/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?"
+  - cmd_regexp: "^.*/(?:sbin|bin)/(?:httpd|apache2)(?:[-_](?:prefork|worker))?(?:.*)?"
     name: Apache WebServer
     pkg_regexp: apache2|^httpd$
     process_type: parent


### PR DESCRIPTION
Fixes a problem with the Apache Webserver regex caused by `/`characters being escaped.