### PR TITLE
Fix Oracle Listener ports iteration and validation system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Fixes
 - Fixed a problem with Oracle Listener ports iteration.
+- Fixed a problem with the validation of the module args where depending on the ansible version an error could happen.
 
 # 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
+# 1.0.2
+
+## Fixes
+- Fixed a problem with Oracle Listener ports iteration.
+
 # 1.0.1
 
 ## Fixes
-- Fixed a problem with the Apache Webserver regex
+- Fixed a problem with the Apache Webserver regex.
 
 # 1.0.0
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.1
+version: 1.0.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/software_discovery/files/tasks_definitions/oracle_listener.yaml
+++ b/roles/software_discovery/files/tasks_definitions/oracle_listener.yaml
@@ -65,7 +65,7 @@
           set_instance_fact:
             _listening_ports: >-
                   << (__instance__._listening_ports | default([]) + __item__
-                  | regex_findall('PORT=(.*?)\)', ignorecase=True) | map('int')) | unique >>
+                  | regex_findall('PORT=(.*?)\)', ignorecase=True) | map('int') | list) | unique >>
           when:
             - "'PORT=' in (__item__ | upper)"
             - "'HTTP' not in (__item__ | upper)"


### PR DESCRIPTION
Fixes a problem with Oracle Listener caused by `map` being used without `list` when merging results.
Also, updates the module args validation with ansible's validation system, solving some problems that could appear in old ansible versions.