### PR TITLE
Add new haproxy_ignore_udp flag for HAProxy software discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.11.0
+
+## Features
+
+- Improve `HAProxy` software discovery with the new flag `haproxy_ignore_udp`, which 
+  ignores UDP bindings and ports.
+
 # 1.10.2
 
 ## Fixed
@@ -14,104 +21,127 @@
 
 ## Features
 
-- Improve `Redis` software discovery with TLS support and enhanced information gathering.
+- Improve `Redis` software discovery with TLS support and enhanced information
+  gathering.
 - Improve `key_value` parser with support for `-` and ` ` in keys.
 
 # 1.9.0
 
 ## Features
+
 - New patroni software discovery.
 
 # 1.8.0
 
 ## Features
+
 - New php-fpm software discovery.
 
 # 1.7.0
 
 ## Features
+
 - Performance improvements in file reading for SNMP Facts.
 
 # 1.6.0
 
 ## Features
+
 - Minor changes on the SNMP template: changed the key `serial_numbers` to `entities`.
 
 # 1.5.0
 
 ## Features
+
 - New snmp_facts module.
 - New snmp_discovery role.
 
 # 1.4.0
 
 ## Features
+
 - Include field `cwd` for modules `process_facts` and `win_process_facts`.
-- When a relative path is given to plugins `read_remote_file` or `add_file_info`, the process `cwd` will be
-  appended to the path to convert it from a relative path to an absolute path, avoiding potential errors.
+- When a relative path is given to plugins `read_remote_file` or `add_file_info`, the
+  process `cwd` will be appended to the path to convert it from a relative path to an
+  absolute path, avoiding potential errors.
 - Strip Ipv6 brackets when present when using plugin `add_binding_info`
 - Increase `postgres` commands timeout from `5` seconds to `10` seconds.
 - Add `SQL Server` failover cluster detection.
 - Improve `Mulesoft` software discovery with specific tasks.
 - Improve `MongoDB` software discovery with specific tasks.
 - Improve `Redis` software discovery with additional tasks for configuration retrieving.
-- Improve `Apache Tomcat` software discovery with enhanced `base` logic and more `HTTP/1.1` protocol detection.
-- Improve `Apache WebServer` software discovery with mod_status check and enhanced field managing.
-- Improve `HAProxy` software discovery with additional tasks for configuration processing.
-- Improve `JBoss Application Server` software discovery by enhancing binding detection and finding the software family.
+- Improve `Apache Tomcat` software discovery with enhanced `base` logic and
+  more `HTTP/1.1` protocol detection.
+- Improve `Apache WebServer` software discovery with mod_status check and enhanced field
+  managing.
+- Improve `HAProxy` software discovery with additional tasks for configuration
+  processing.
+- Improve `JBoss Application Server` software discovery by enhancing binding detection
+  and finding the software family.
 - Improve `Nginx WebServer` ports processing.
 - Enhanced cmd regex for `Apache Tomcat` and `Apache WebServer` detection.
 - Attributes `class`, `type` and `subtype` refined for:
-  - `Apache ActiveMQ`
-  - `Apache WebServer`
-  - `JBoss Application Server`
-  - `Oracle DatabaseServer`
-  - `Oracle Listener`
+    - `Apache ActiveMQ`
+    - `Apache WebServer`
+    - `JBoss Application Server`
+    - `Oracle DatabaseServer`
+    - `Oracle Listener`
 
 ## Fixes
+
 - Handling of empty path for `add_file_info` plugin.
 - Malformed regex usage for `Apache Webserver`.
-- Role `docker_containers` now is able to handle machines where docker is installed but stopped.
+- Role `docker_containers` now is able to handle machines where docker is installed but
+  stopped.
 
 # 1.3.1
 
 ## Fixes
+
 - Unexpected errors handling for SQL Server and IIS.
 
 # 1.3.0
 
 ## Features
+
 - Added support for PostgreSQL Database for Windows OS.
 - The `run_command` builtin plugin now supports Windows hosts.
 
 # 1.2.0
 
 ## Features
+
 - win_hyperv_facts module now shows hard_drives by default.
 
 ## Fixes
+
 - win_process_facts module now uses same field types as process_facts.
 
 # 1.1.1
 
 ## Fixes
+
 - Fixed a problem with the system identification when running tasks.
 
 # 1.1.0
 
 ## Features
+
 - New win_hyperv_facts module.
 - New hyperv_vms role.
 
 # 1.0.2
 
 ## Fixes
+
 - Fixed a problem with Oracle Listener ports iteration.
-- Fixed a problem with the validation of the module args where depending on the ansible version an error could happen.
+- Fixed a problem with the validation of the module args where depending on the ansible
+  version an error could happen.
 
 # 1.0.1
 
 ## Fixes
+
 - Fixed a problem with the Apache Webserver regex.
 
 # 1.0.0
@@ -121,6 +151,7 @@ Initial version of `datadope.discovery` Ansible collection.
 ## Collection components
 
 ### Modules
+
 - check_connection
 - file_parser
 - process_facts
@@ -130,10 +161,12 @@ Initial version of `datadope.discovery` Ansible collection.
 - win_process_facts
 
 ### Roles
+
 - docker_containers
 - software_discovery
 
 ### Playbook
+
 - software_discovery.yml
 
 ## Supported software types

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.10.2
+version: 1.11.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/software_discovery/defaults/main.yml
+++ b/roles/software_discovery/defaults/main.yml
@@ -111,6 +111,8 @@ software_discovery__software_list:
     process_type: parent
     return_children: true
     return_packages: true
+    vars:
+      ignore_udp: "{{ haproxy_ignore_udp | default(true) }}"
     custom_tasks:
       - name: Include HAProxy specific plugins
         include_tasks:

--- a/roles/software_discovery/files/tasks_definitions/haproxy.yaml
+++ b/roles/software_discovery/files/tasks_definitions/haproxy.yaml
@@ -167,9 +167,30 @@
       when: __instance__._stats_bind_entries is defined
   when: __instance__.configuration is defined
 
+- name: Exclude UDP ports if needed
+  block:
+    - name: Iterate over bindings
+      block:
+        - name: Store binding if not UDP
+          set_instance_fact:
+            _cleared_bindings: "<< __instance__._cleared_bindings | default([]) + [__item__] >>"
+          when: __item__.protocol | default('tcp') | lower != 'udp'
+        - name: Remove binding from listening_ports if UDP
+          set_instance_fact:
+            listening_ports: "<< __instance__.listening_ports | reject('search', '^' + __item__.port | string + '$') | list >>"
+          when: __item__.protocol | default('tcp') | lower == 'udp'
+      when: __item__.port is defined
+      loop: "<< __instance__.bindings | default([]) >>"
+    - name: Store processed bindings
+      set_instance_fact:
+        bindings: "<< __instance__._cleared_bindings >>"
+      when: __instance__._cleared_bindings is defined
+  when: ignore_udp
+
 - name: Remove temporary vars
   del_instance_fact:
     - _conf_files_paths
     - _bind_entries
     - _stats_socket_path
     - _stats_bind_entries
+    - _cleared_bindings

--- a/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6_with_udp.yaml
+++ b/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6_with_udp.yaml
@@ -4401,6 +4401,8 @@ software_list:
   process_type: parent
   return_children: true
   return_packages: true
+  vars:
+    ignore_udp: False
 tcp_listen:
 - address: 0.0.0.0
   name: rpcbind

--- a/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6_without_udp.yaml
+++ b/tests/unit/plugins/action/auto/resources/haproxy/haproxy1.5.18_centos7.6_without_udp.yaml
@@ -1,0 +1,4577 @@
+dockers:
+  containers: []
+expected_result:
+- bindings:
+  - address: 0.0.0.0
+    class: service
+    port: 83
+    protocol: tcp
+  - address: 0.0.0.0
+    class: service
+    port: 5000
+    protocol: tcp
+  configuration:
+    backend app:
+      balance: roundrobin
+      server:
+      - app1 127.0.0.1:5001 check
+      - app2 127.0.0.1:5002 check
+      - app3 127.0.0.1:5003 check
+      - app4 127.0.0.1:5004 check
+    backend micro02:
+      balance: leastconn
+      mode: http
+      option:
+      - http-server-close
+      - forwardfor
+      server:
+      - loadbalancer-1 192.168.0.142:8080 check
+      - loadbalancer-2 192.168.0.223:8080 check
+      timeout:
+      - http-keep-alive 300
+      - connect 10s
+      - server 1m
+    backend static:
+      balance: roundrobin
+      server: static 127.0.0.1:4331 check
+    defaults:
+      log: global
+      maxconn: '3000'
+      mode: http
+      option:
+      - httplog
+      - dontlognull
+      - http-server-close
+      - forwardfor       except 127.0.0.0/8
+      - redispatch
+      retries: '3'
+      timeout:
+      - http-request    10s
+      - queue           1m
+      - connect         10s
+      - client          1m
+      - server          1m
+      - http-keep-alive 10s
+      - check           10s
+    frontend main:
+      '*:5000': null
+      acl:
+      - url_static       path_beg       -i /static /images /javascript /stylesheets
+      - url_static       path_end       -i .jpg .gif .png .css .js
+      default_backend: app
+      use_backend: static          if url_static
+    frontend micro-http-02:
+      bind: '*:83'
+      default_backend: micro02
+      reqadd: X-Forwarded-Proto:\ http
+    global:
+      chroot: /var/lib/haproxy
+      daemon: null
+      group: haproxy
+      log: 127.0.0.1 local2
+      maxconn: '4000'
+      pidfile: /var/run/haproxy.pid
+      stats: socket /var/lib/haproxy/stats
+      user: haproxy
+  discovery_time: '2022-06-16T23:16:05+02:00'
+  extra_data:
+    binded_ports:
+      - '*:83'
+    stats_socket_path: /var/lib/haproxy/stats
+  files:
+  - name: haproxy.cfg
+    path: /etc/haproxy
+    subtype: generic
+    type: config
+  listening_ports:
+  - 83
+  - 5000
+  packages:
+  - arch: x86_64
+    epoch: null
+    name: haproxy
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  process:
+    children:
+    - children: []
+      cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+      cwd: /usr/sbin/
+      listening_ports:
+      - 83
+      - 5000
+      pid: '905'
+      ppid: '896'
+      user: haproxy
+    cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+    cwd: /usr/sbin/
+    listening_ports:
+    - 49899
+    pid: '896'
+    ppid: '891'
+    user: haproxy
+  type: HAProxy
+  version:
+  - number: 1.5.18
+    type: package
+mocked_plugin_tasks:
+  Check if config file is accesible:
+    expected_args:
+      follow: false
+      get_attributes: true
+      get_mime: true
+      in_docker: true
+      path: /etc/haproxy/haproxy.cfg
+    plugin_result:
+      failed: false
+  Parse config file:
+    plugin_result:
+      failed: false
+      parsed:
+        backend app:
+          balance: roundrobin
+          server:
+          - app1 127.0.0.1:5001 check
+          - app2 127.0.0.1:5002 check
+          - app3 127.0.0.1:5003 check
+          - app4 127.0.0.1:5004 check
+        backend micro02:
+          balance: leastconn
+          mode: http
+          option:
+          - http-server-close
+          - forwardfor
+          server:
+          - loadbalancer-1 192.168.0.142:8080 check
+          - loadbalancer-2 192.168.0.223:8080 check
+          timeout:
+          - http-keep-alive 300
+          - connect 10s
+          - server 1m
+        backend static:
+          balance: roundrobin
+          server: static 127.0.0.1:4331 check
+        defaults:
+          log: global
+          maxconn: '3000'
+          mode: http
+          option:
+          - httplog
+          - dontlognull
+          - http-server-close
+          - forwardfor       except 127.0.0.0/8
+          - redispatch
+          retries: '3'
+          timeout:
+          - http-request    10s
+          - queue           1m
+          - connect         10s
+          - client          1m
+          - server          1m
+          - http-keep-alive 10s
+          - check           10s
+        frontend main:
+          '*:5000': null
+          acl:
+          - url_static       path_beg       -i /static /images /javascript /stylesheets
+          - url_static       path_end       -i .jpg .gif .png .css .js
+          default_backend: app
+          use_backend: static          if url_static
+        frontend micro-http-02:
+          bind: '*:83'
+          default_backend: micro02
+          reqadd: X-Forwarded-Proto:\ http
+        global:
+          chroot: /var/lib/haproxy
+          daemon: null
+          group: haproxy
+          log: 127.0.0.1 local2
+          maxconn: '4000'
+          pidfile: /var/run/haproxy.pid
+          stats: socket /var/lib/haproxy/stats
+          user: haproxy
+  Read process environment:
+    plugin_result:
+      failed: false
+      parsed:
+        LANG: en_US.UTF-8
+        OPTIONS: ''
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+packages:
+  PyYAML:
+  - arch: x86_64
+    epoch: null
+    name: PyYAML
+    release: 11.el7
+    source: rpm
+    version: '3.10'
+  acl:
+  - arch: x86_64
+    epoch: null
+    name: acl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  alsa-lib:
+  - arch: x86_64
+    epoch: null
+    name: alsa-lib
+    release: 1.el7
+    source: rpm
+    version: 1.1.8
+  apache-commons-collections:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-collections
+    release: 22.el7_2
+    source: rpm
+    version: 3.2.1
+  apache-commons-daemon:
+  - arch: x86_64
+    epoch: null
+    name: apache-commons-daemon
+    release: 7.el7
+    source: rpm
+    version: 1.0.13
+  apache-commons-dbcp:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-dbcp
+    release: 17.el7
+    source: rpm
+    version: '1.4'
+  apache-commons-logging:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-logging
+    release: 7.el7
+    source: rpm
+    version: 1.1.2
+  apache-commons-pool:
+  - arch: noarch
+    epoch: null
+    name: apache-commons-pool
+    release: 9.el7
+    source: rpm
+    version: '1.6'
+  apr:
+  - arch: x86_64
+    epoch: null
+    name: apr
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-devel
+    release: 7.el7
+    source: rpm
+    version: 1.4.8
+  apr-util:
+  - arch: x86_64
+    epoch: null
+    name: apr-util
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  apr-util-devel:
+  - arch: x86_64
+    epoch: null
+    name: apr-util-devel
+    release: 6.el7
+    source: rpm
+    version: 1.5.2
+  atk:
+  - arch: x86_64
+    epoch: null
+    name: atk
+    release: 2.el7
+    source: rpm
+    version: 2.28.1
+  audit:
+  - arch: x86_64
+    epoch: null
+    name: audit
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  audit-libs-python:
+  - arch: x86_64
+    epoch: null
+    name: audit-libs-python
+    release: 4.el7
+    source: rpm
+    version: 2.8.5
+  authconfig:
+  - arch: x86_64
+    epoch: null
+    name: authconfig
+    release: 30.el7
+    source: rpm
+    version: 6.2.8
+  autoconf:
+  - arch: noarch
+    epoch: null
+    name: autoconf
+    release: 11.el7
+    source: rpm
+    version: '2.69'
+  automake:
+  - arch: noarch
+    epoch: null
+    name: automake
+    release: 3.el7
+    source: rpm
+    version: 1.13.4
+  avahi-libs:
+  - arch: x86_64
+    epoch: null
+    name: avahi-libs
+    release: 20.el7
+    source: rpm
+    version: 0.6.31
+  avalon-framework:
+  - arch: noarch
+    epoch: 0
+    name: avalon-framework
+    release: 10.el7
+    source: rpm
+    version: '4.3'
+  avalon-logkit:
+  - arch: noarch
+    epoch: 0
+    name: avalon-logkit
+    release: 14.el7
+    source: rpm
+    version: '2.1'
+  basesystem:
+  - arch: noarch
+    epoch: null
+    name: basesystem
+    release: 7.el7.centos
+    source: rpm
+    version: '10.0'
+  bash:
+  - arch: x86_64
+    epoch: null
+    name: bash
+    release: 34.el7
+    source: rpm
+    version: 4.2.46
+  bind-export-libs:
+  - arch: x86_64
+    epoch: 32
+    name: bind-export-libs
+    release: 16.P2.el7_8.2
+    source: rpm
+    version: 9.11.4
+  binutils:
+  - arch: x86_64
+    epoch: null
+    name: binutils
+    release: 43.base.el7
+    source: rpm
+    version: '2.27'
+  btrfs-progs:
+  - arch: x86_64
+    epoch: null
+    name: btrfs-progs
+    release: 1.el7
+    source: rpm
+    version: 4.9.1
+  bzip2-libs:
+  - arch: x86_64
+    epoch: null
+    name: bzip2-libs
+    release: 13.el7
+    source: rpm
+    version: 1.0.6
+  ca-certificates:
+  - arch: noarch
+    epoch: null
+    name: ca-certificates
+    release: 76.el7_7
+    source: rpm
+    version: 2019.2.32
+  cairo:
+  - arch: x86_64
+    epoch: null
+    name: cairo
+    release: 4.el7
+    source: rpm
+    version: 1.15.12
+  centos-indexhtml:
+  - arch: noarch
+    epoch: null
+    name: centos-indexhtml
+    release: 9.el7.centos
+    source: rpm
+    version: '7'
+  centos-logos:
+  - arch: noarch
+    epoch: null
+    name: centos-logos
+    release: 3.el7.centos
+    source: rpm
+    version: 70.0.6
+  centos-release:
+  - arch: x86_64
+    epoch: null
+    name: centos-release
+    release: 8.2003.0.el7.centos
+    source: rpm
+    version: '7'
+  centos-release-scl-rh:
+  - arch: noarch
+    epoch: null
+    name: centos-release-scl-rh
+    release: 3.el7.centos
+    source: rpm
+    version: '2'
+  checkpolicy:
+  - arch: x86_64
+    epoch: null
+    name: checkpolicy
+    release: 8.el7
+    source: rpm
+    version: '2.5'
+  chkconfig:
+  - arch: x86_64
+    epoch: null
+    name: chkconfig
+    release: 1.el7
+    source: rpm
+    version: 1.7.4
+  chrony:
+  - arch: x86_64
+    epoch: null
+    name: chrony
+    release: 1.el7
+    source: rpm
+    version: '3.4'
+  cloud-init:
+  - arch: x86_64
+    epoch: null
+    name: cloud-init
+    release: 6.el7.centos
+    source: rpm
+    version: '18.5'
+  cloud-utils-growpart:
+  - arch: noarch
+    epoch: null
+    name: cloud-utils-growpart
+    release: 5.el7
+    source: rpm
+    version: '0.29'
+  copy-jdk-configs:
+  - arch: noarch
+    epoch: null
+    name: copy-jdk-configs
+    release: 10.el7_5
+    source: rpm
+    version: '3.3'
+  coreutils:
+  - arch: x86_64
+    epoch: null
+    name: coreutils
+    release: 24.el7
+    source: rpm
+    version: '8.22'
+  cpio:
+  - arch: x86_64
+    epoch: null
+    name: cpio
+    release: 27.el7
+    source: rpm
+    version: '2.11'
+  cpp:
+  - arch: x86_64
+    epoch: null
+    name: cpp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  cracklib:
+  - arch: x86_64
+    epoch: null
+    name: cracklib
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cracklib-dicts:
+  - arch: x86_64
+    epoch: null
+    name: cracklib-dicts
+    release: 11.el7
+    source: rpm
+    version: 2.9.0
+  cronie:
+  - arch: x86_64
+    epoch: null
+    name: cronie
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  cronie-anacron:
+  - arch: x86_64
+    epoch: null
+    name: cronie-anacron
+    release: 23.el7
+    source: rpm
+    version: 1.4.11
+  crontabs:
+  - arch: noarch
+    epoch: null
+    name: crontabs
+    release: 6.20121102git.el7
+    source: rpm
+    version: '1.11'
+  cryptsetup-libs:
+  - arch: x86_64
+    epoch: null
+    name: cryptsetup-libs
+    release: 6.el7
+    source: rpm
+    version: 2.0.3
+  cups-libs:
+  - arch: x86_64
+    epoch: 1
+    name: cups-libs
+    release: 51.el7
+    source: rpm
+    version: 1.6.3
+  curl:
+  - arch: x86_64
+    epoch: null
+    name: curl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  cyrus-sasl:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-devel:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-devel
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  cyrus-sasl-lib:
+  - arch: x86_64
+    epoch: null
+    name: cyrus-sasl-lib
+    release: 23.el7
+    source: rpm
+    version: 2.1.26
+  dbus:
+  - arch: x86_64
+    epoch: 1
+    name: dbus
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-glib:
+  - arch: x86_64
+    epoch: null
+    name: dbus-glib
+    release: 7.el7
+    source: rpm
+    version: '0.100'
+  dbus-libs:
+  - arch: x86_64
+    epoch: 1
+    name: dbus-libs
+    release: 13.el7_6
+    source: rpm
+    version: 1.10.24
+  dbus-python:
+  - arch: x86_64
+    epoch: null
+    name: dbus-python
+    release: 9.el7
+    source: rpm
+    version: 1.1.1
+  dejavu-fonts-common:
+  - arch: noarch
+    epoch: null
+    name: dejavu-fonts-common
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  dejavu-sans-fonts:
+  - arch: noarch
+    epoch: null
+    name: dejavu-sans-fonts
+    release: 6.el7
+    source: rpm
+    version: '2.33'
+  device-mapper:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  device-mapper-libs:
+  - arch: x86_64
+    epoch: 7
+    name: device-mapper-libs
+    release: 7.el7_8.1
+    source: rpm
+    version: 1.02.164
+  devtoolset-7-binutils:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-binutils
+    release: 11.el7
+    source: rpm
+    version: '2.28'
+  devtoolset-7-gcc:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-gcc-c++
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-libstdc++-devel
+    release: 5.16.el7
+    source: rpm
+    version: 7.3.1
+  devtoolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: devtoolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: '7.1'
+  dhclient:
+  - arch: x86_64
+    epoch: 12
+    name: dhclient
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-common:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-common
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  dhcp-libs:
+  - arch: x86_64
+    epoch: 12
+    name: dhcp-libs
+    release: 79.el7.centos
+    source: rpm
+    version: 4.2.5
+  diffutils:
+  - arch: x86_64
+    epoch: null
+    name: diffutils
+    release: 5.el7
+    source: rpm
+    version: '3.3'
+  dmidecode:
+  - arch: x86_64
+    epoch: 1
+    name: dmidecode
+    release: 3.el7
+    source: rpm
+    version: '3.2'
+  dracut:
+  - arch: x86_64
+    epoch: null
+    name: dracut
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-generic:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-generic
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-config-rescue:
+  - arch: x86_64
+    epoch: null
+    name: dracut-config-rescue
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dracut-network:
+  - arch: x86_64
+    epoch: null
+    name: dracut-network
+    release: 568.el7
+    source: rpm
+    version: '033'
+  dwz:
+  - arch: x86_64
+    epoch: null
+    name: dwz
+    release: 3.el7
+    source: rpm
+    version: '0.11'
+  e2fsprogs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  e2fsprogs-libs:
+  - arch: x86_64
+    epoch: null
+    name: e2fsprogs-libs
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  ecj:
+  - arch: x86_64
+    epoch: 1
+    name: ecj
+    release: 3.el7
+    source: rpm
+    version: 4.5.2
+  elfutils-default-yama-scope:
+  - arch: noarch
+    epoch: null
+    name: elfutils-default-yama-scope
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libelf:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libelf
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  elfutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: elfutils-libs
+    release: 4.el7
+    source: rpm
+    version: '0.176'
+  epel-release:
+  - arch: noarch
+    epoch: null
+    name: epel-release
+    release: '11'
+    source: rpm
+    version: '7'
+  ethtool:
+  - arch: x86_64
+    epoch: 2
+    name: ethtool
+    release: 10.el7
+    source: rpm
+    version: '4.8'
+  expat:
+  - arch: x86_64
+    epoch: null
+    name: expat
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  expat-devel:
+  - arch: x86_64
+    epoch: null
+    name: expat-devel
+    release: 12.el7
+    source: rpm
+    version: 2.1.0
+  file:
+  - arch: x86_64
+    epoch: null
+    name: file
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  file-libs:
+  - arch: x86_64
+    epoch: null
+    name: file-libs
+    release: 36.el7
+    source: rpm
+    version: '5.11'
+  filesystem:
+  - arch: x86_64
+    epoch: null
+    name: filesystem
+    release: 25.el7
+    source: rpm
+    version: '3.2'
+  findutils:
+  - arch: x86_64
+    epoch: 1
+    name: findutils
+    release: 6.el7
+    source: rpm
+    version: 4.5.11
+  fipscheck:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fipscheck-lib:
+  - arch: x86_64
+    epoch: null
+    name: fipscheck-lib
+    release: 6.el7
+    source: rpm
+    version: 1.4.1
+  fontconfig:
+  - arch: x86_64
+    epoch: null
+    name: fontconfig
+    release: 4.3.el7
+    source: rpm
+    version: 2.13.0
+  fontpackages-filesystem:
+  - arch: noarch
+    epoch: null
+    name: fontpackages-filesystem
+    release: 8.el7
+    source: rpm
+    version: '1.44'
+  freetype:
+  - arch: x86_64
+    epoch: null
+    name: freetype
+    release: 14.el7
+    source: rpm
+    version: '2.8'
+  fribidi:
+  - arch: x86_64
+    epoch: null
+    name: fribidi
+    release: 1.el7_7.1
+    source: rpm
+    version: 1.0.2
+  gawk:
+  - arch: x86_64
+    epoch: null
+    name: gawk
+    release: 4.el7_3.1
+    source: rpm
+    version: 4.0.2
+  gcc:
+  - arch: x86_64
+    epoch: null
+    name: gcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gcc-c++:
+  - arch: x86_64
+    epoch: null
+    name: gcc-c++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  gdbm:
+  - arch: x86_64
+    epoch: null
+    name: gdbm
+    release: 8.el7
+    source: rpm
+    version: '1.10'
+  gdk-pixbuf2:
+  - arch: x86_64
+    epoch: null
+    name: gdk-pixbuf2
+    release: 3.el7
+    source: rpm
+    version: 2.36.12
+  geronimo-jms:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jms
+    release: 19.el7
+    source: rpm
+    version: 1.1.1
+  geronimo-jta:
+  - arch: noarch
+    epoch: null
+    name: geronimo-jta
+    release: 17.el7
+    source: rpm
+    version: 1.1.1
+  gettext:
+  - arch: x86_64
+    epoch: null
+    name: gettext
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  gettext-libs:
+  - arch: x86_64
+    epoch: null
+    name: gettext-libs
+    release: 3.el7
+    source: rpm
+    version: 0.19.8.1
+  giflib:
+  - arch: x86_64
+    epoch: null
+    name: giflib
+    release: 9.el7
+    source: rpm
+    version: 4.1.6
+  glib2:
+  - arch: x86_64
+    epoch: null
+    name: glib2
+    release: 5.el7
+    source: rpm
+    version: 2.56.1
+  glibc:
+  - arch: x86_64
+    epoch: null
+    name: glibc
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-common:
+  - arch: x86_64
+    epoch: null
+    name: glibc-common
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-devel:
+  - arch: x86_64
+    epoch: null
+    name: glibc-devel
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  glibc-headers:
+  - arch: x86_64
+    epoch: null
+    name: glibc-headers
+    release: 324.el7_9
+    source: rpm
+    version: '2.17'
+  gmp:
+  - arch: x86_64
+    epoch: 1
+    name: gmp
+    release: 15.el7
+    source: rpm
+    version: 6.0.0
+  gnupg2:
+  - arch: x86_64
+    epoch: null
+    name: gnupg2
+    release: 5.el7_5
+    source: rpm
+    version: 2.0.22
+  gobject-introspection:
+  - arch: x86_64
+    epoch: null
+    name: gobject-introspection
+    release: 1.el7
+    source: rpm
+    version: 1.56.1
+  gperftools-libs:
+  - arch: x86_64
+    epoch: null
+    name: gperftools-libs
+    release: 1.el7
+    source: rpm
+    version: 2.6.1
+  gpg-pubkey:
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 53a7ff4b
+    source: rpm
+    version: f4a80eb5
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 608c8351
+    source: rpm
+    version: 442df0f8
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 560cfc0a
+    source: rpm
+    version: f2ee9d55
+  - arch: null
+    epoch: null
+    name: gpg-pubkey
+    release: 52ae6884
+    source: rpm
+    version: 352c64e5
+  gpgme:
+  - arch: x86_64
+    epoch: null
+    name: gpgme
+    release: 5.el7
+    source: rpm
+    version: 1.3.2
+  graphite2:
+  - arch: x86_64
+    epoch: null
+    name: graphite2
+    release: 1.el7_3
+    source: rpm
+    version: 1.3.10
+  grep:
+  - arch: x86_64
+    epoch: null
+    name: grep
+    release: 3.el7
+    source: rpm
+    version: '2.20'
+  groff-base:
+  - arch: x86_64
+    epoch: null
+    name: groff-base
+    release: 8.el7
+    source: rpm
+    version: 1.22.2
+  grub2:
+  - arch: x86_64
+    epoch: 1
+    name: grub2
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-common:
+  - arch: noarch
+    epoch: 1
+    name: grub2-common
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-pc
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-pc-modules:
+  - arch: noarch
+    epoch: 1
+    name: grub2-pc-modules
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-extra:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-extra
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grub2-tools-minimal:
+  - arch: x86_64
+    epoch: 1
+    name: grub2-tools-minimal
+    release: 0.81.el7.centos
+    source: rpm
+    version: '2.02'
+  grubby:
+  - arch: x86_64
+    epoch: null
+    name: grubby
+    release: 26.el7
+    source: rpm
+    version: '8.28'
+  gssproxy:
+  - arch: x86_64
+    epoch: null
+    name: gssproxy
+    release: 28.el7
+    source: rpm
+    version: 0.7.0
+  gtk-update-icon-cache:
+  - arch: x86_64
+    epoch: null
+    name: gtk-update-icon-cache
+    release: 6.el7
+    source: rpm
+    version: 3.22.30
+  gtk2:
+  - arch: x86_64
+    epoch: null
+    name: gtk2
+    release: 1.el7
+    source: rpm
+    version: 2.24.31
+  gzip:
+  - arch: x86_64
+    epoch: null
+    name: gzip
+    release: 10.el7
+    source: rpm
+    version: '1.5'
+  haproxy:
+  - arch: x86_64
+    epoch: null
+    name: haproxy
+    release: 9.el7_9.1
+    source: rpm
+    version: 1.5.18
+  hardlink:
+  - arch: x86_64
+    epoch: 1
+    name: hardlink
+    release: 19.el7
+    source: rpm
+    version: '1.0'
+  harfbuzz:
+  - arch: x86_64
+    epoch: null
+    name: harfbuzz
+    release: 2.el7
+    source: rpm
+    version: 1.7.5
+  hicolor-icon-theme:
+  - arch: noarch
+    epoch: null
+    name: hicolor-icon-theme
+    release: 7.el7
+    source: rpm
+    version: '0.12'
+  hostname:
+  - arch: x86_64
+    epoch: null
+    name: hostname
+    release: 3.el7_7.1
+    source: rpm
+    version: '3.13'
+  httpd:
+  - arch: x86_64
+    epoch: null
+    name: httpd
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-devel:
+  - arch: x86_64
+    epoch: null
+    name: httpd-devel
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  httpd-tools:
+  - arch: x86_64
+    epoch: null
+    name: httpd-tools
+    release: 97.el7.centos
+    source: rpm
+    version: 2.4.6
+  hwdata:
+  - arch: x86_64
+    epoch: null
+    name: hwdata
+    release: 9.5.el7
+    source: rpm
+    version: '0.252'
+  info:
+  - arch: x86_64
+    epoch: null
+    name: info
+    release: 5.el7
+    source: rpm
+    version: '5.1'
+  initscripts:
+  - arch: x86_64
+    epoch: null
+    name: initscripts
+    release: 1.el7
+    source: rpm
+    version: 9.49.49
+  iproute:
+  - arch: x86_64
+    epoch: null
+    name: iproute
+    release: 25.el7_7.2
+    source: rpm
+    version: 4.11.0
+  ipset-libs:
+  - arch: x86_64
+    epoch: null
+    name: ipset-libs
+    release: 1.el7
+    source: rpm
+    version: '7.1'
+  iptables:
+  - arch: x86_64
+    epoch: null
+    name: iptables
+    release: 34.el7
+    source: rpm
+    version: 1.4.21
+  iputils:
+  - arch: x86_64
+    epoch: null
+    name: iputils
+    release: 10.el7
+    source: rpm
+    version: '20160308'
+  irqbalance:
+  - arch: x86_64
+    epoch: 3
+    name: irqbalance
+    release: 12.el7
+    source: rpm
+    version: 1.0.7
+  jakarta-taglibs-standard:
+  - arch: noarch
+    epoch: 0
+    name: jakarta-taglibs-standard
+    release: 14.el7_1
+    source: rpm
+    version: 1.1.2
+  jansson:
+  - arch: x86_64
+    epoch: null
+    name: jansson
+    release: 1.el7
+    source: rpm
+    version: '2.10'
+  jasper-libs:
+  - arch: x86_64
+    epoch: null
+    name: jasper-libs
+    release: 33.el7
+    source: rpm
+    version: 1.900.1
+  java-1.8.0-openjdk:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  java-1.8.0-openjdk-headless:
+  - arch: x86_64
+    epoch: 1
+    name: java-1.8.0-openjdk-headless
+    release: 0.el7_9
+    source: rpm
+    version: 1.8.0.302.b08
+  javamail:
+  - arch: noarch
+    epoch: null
+    name: javamail
+    release: 8.el7
+    source: rpm
+    version: 1.4.6
+  javapackages-tools:
+  - arch: noarch
+    epoch: null
+    name: javapackages-tools
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  jbigkit-libs:
+  - arch: x86_64
+    epoch: null
+    name: jbigkit-libs
+    release: 11.el7
+    source: rpm
+    version: '2.0'
+  json-c:
+  - arch: x86_64
+    epoch: null
+    name: json-c
+    release: 4.el7_0
+    source: rpm
+    version: '0.11'
+  kbd:
+  - arch: x86_64
+    epoch: null
+    name: kbd
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-legacy:
+  - arch: noarch
+    epoch: null
+    name: kbd-legacy
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  kbd-misc:
+  - arch: noarch
+    epoch: null
+    name: kbd-misc
+    release: 15.el7
+    source: rpm
+    version: 1.15.5
+  keepalived:
+  - arch: x86_64
+    epoch: null
+    name: keepalived
+    release: 19.el7
+    source: rpm
+    version: 1.3.5
+  kernel:
+  - arch: x86_64
+    epoch: null
+    name: kernel
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-headers:
+  - arch: x86_64
+    epoch: null
+    name: kernel-headers
+    release: 1160.42.2.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kernel-tools-libs:
+  - arch: x86_64
+    epoch: null
+    name: kernel-tools-libs
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  kexec-tools:
+  - arch: x86_64
+    epoch: null
+    name: kexec-tools
+    release: 43.el7
+    source: rpm
+    version: 2.0.15
+  keyutils:
+  - arch: x86_64
+    epoch: null
+    name: keyutils
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  keyutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: keyutils-libs
+    release: 3.el7
+    source: rpm
+    version: 1.5.8
+  kmod:
+  - arch: x86_64
+    epoch: null
+    name: kmod
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kmod-libs:
+  - arch: x86_64
+    epoch: null
+    name: kmod-libs
+    release: 28.el7
+    source: rpm
+    version: '20'
+  kpartx:
+  - arch: x86_64
+    epoch: null
+    name: kpartx
+    release: 131.el7
+    source: rpm
+    version: 0.4.9
+  krb5-libs:
+  - arch: x86_64
+    epoch: null
+    name: krb5-libs
+    release: 46.el7
+    source: rpm
+    version: 1.15.1
+  less:
+  - arch: x86_64
+    epoch: null
+    name: less
+    release: 9.el7
+    source: rpm
+    version: '458'
+  libICE:
+  - arch: x86_64
+    epoch: null
+    name: libICE
+    release: 9.el7
+    source: rpm
+    version: 1.0.9
+  libSM:
+  - arch: x86_64
+    epoch: null
+    name: libSM
+    release: 2.el7
+    source: rpm
+    version: 1.2.2
+  libX11:
+  - arch: x86_64
+    epoch: null
+    name: libX11
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libX11-common:
+  - arch: noarch
+    epoch: null
+    name: libX11-common
+    release: 4.el7_9
+    source: rpm
+    version: 1.6.7
+  libXau:
+  - arch: x86_64
+    epoch: null
+    name: libXau
+    release: 2.1.el7
+    source: rpm
+    version: 1.0.8
+  libXcomposite:
+  - arch: x86_64
+    epoch: null
+    name: libXcomposite
+    release: 4.1.el7
+    source: rpm
+    version: 0.4.4
+  libXcursor:
+  - arch: x86_64
+    epoch: null
+    name: libXcursor
+    release: 1.el7
+    source: rpm
+    version: 1.1.15
+  libXdamage:
+  - arch: x86_64
+    epoch: null
+    name: libXdamage
+    release: 4.1.el7
+    source: rpm
+    version: 1.1.4
+  libXext:
+  - arch: x86_64
+    epoch: null
+    name: libXext
+    release: 3.el7
+    source: rpm
+    version: 1.3.3
+  libXfixes:
+  - arch: x86_64
+    epoch: null
+    name: libXfixes
+    release: 1.el7
+    source: rpm
+    version: 5.0.3
+  libXft:
+  - arch: x86_64
+    epoch: null
+    name: libXft
+    release: 2.el7
+    source: rpm
+    version: 2.3.2
+  libXi:
+  - arch: x86_64
+    epoch: null
+    name: libXi
+    release: 1.el7
+    source: rpm
+    version: 1.7.9
+  libXinerama:
+  - arch: x86_64
+    epoch: null
+    name: libXinerama
+    release: 2.1.el7
+    source: rpm
+    version: 1.1.3
+  libXrandr:
+  - arch: x86_64
+    epoch: null
+    name: libXrandr
+    release: 2.el7
+    source: rpm
+    version: 1.5.1
+  libXrender:
+  - arch: x86_64
+    epoch: null
+    name: libXrender
+    release: 1.el7
+    source: rpm
+    version: 0.9.10
+  libXtst:
+  - arch: x86_64
+    epoch: null
+    name: libXtst
+    release: 1.el7
+    source: rpm
+    version: 1.2.3
+  libXxf86vm:
+  - arch: x86_64
+    epoch: null
+    name: libXxf86vm
+    release: 1.el7
+    source: rpm
+    version: 1.1.4
+  libacl:
+  - arch: x86_64
+    epoch: null
+    name: libacl
+    release: 15.el7
+    source: rpm
+    version: 2.2.51
+  libassuan:
+  - arch: x86_64
+    epoch: null
+    name: libassuan
+    release: 3.el7
+    source: rpm
+    version: 2.1.0
+  libattr:
+  - arch: x86_64
+    epoch: null
+    name: libattr
+    release: 13.el7
+    source: rpm
+    version: 2.4.46
+  libbasicobjects:
+  - arch: x86_64
+    epoch: null
+    name: libbasicobjects
+    release: 32.el7
+    source: rpm
+    version: 0.1.1
+  libblkid:
+  - arch: x86_64
+    epoch: null
+    name: libblkid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libcap:
+  - arch: x86_64
+    epoch: null
+    name: libcap
+    release: 11.el7
+    source: rpm
+    version: '2.22'
+  libcap-ng:
+  - arch: x86_64
+    epoch: null
+    name: libcap-ng
+    release: 4.el7
+    source: rpm
+    version: 0.7.5
+  libcgroup:
+  - arch: x86_64
+    epoch: null
+    name: libcgroup
+    release: 21.el7
+    source: rpm
+    version: '0.41'
+  libcollection:
+  - arch: x86_64
+    epoch: null
+    name: libcollection
+    release: 32.el7
+    source: rpm
+    version: 0.7.0
+  libcom_err:
+  - arch: x86_64
+    epoch: null
+    name: libcom_err
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libcroco:
+  - arch: x86_64
+    epoch: null
+    name: libcroco
+    release: 4.el7
+    source: rpm
+    version: 0.6.12
+  libcurl:
+  - arch: x86_64
+    epoch: null
+    name: libcurl
+    release: 57.el7
+    source: rpm
+    version: 7.29.0
+  libdaemon:
+  - arch: x86_64
+    epoch: null
+    name: libdaemon
+    release: 7.el7
+    source: rpm
+    version: '0.14'
+  libdb:
+  - arch: x86_64
+    epoch: null
+    name: libdb
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-devel:
+  - arch: x86_64
+    epoch: null
+    name: libdb-devel
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdb-utils:
+  - arch: x86_64
+    epoch: null
+    name: libdb-utils
+    release: 25.el7
+    source: rpm
+    version: 5.3.21
+  libdrm:
+  - arch: x86_64
+    epoch: null
+    name: libdrm
+    release: 2.el7
+    source: rpm
+    version: 2.4.97
+  libedit:
+  - arch: x86_64
+    epoch: null
+    name: libedit
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libedit-devel:
+  - arch: x86_64
+    epoch: null
+    name: libedit-devel
+    release: 12.20121213cvs.el7
+    source: rpm
+    version: '3.0'
+  libestr:
+  - arch: x86_64
+    epoch: null
+    name: libestr
+    release: 2.el7
+    source: rpm
+    version: 0.1.9
+  libevent:
+  - arch: x86_64
+    epoch: null
+    name: libevent
+    release: 4.el7
+    source: rpm
+    version: 2.0.21
+  libfastjson:
+  - arch: x86_64
+    epoch: null
+    name: libfastjson
+    release: 3.el7
+    source: rpm
+    version: 0.99.4
+  libffi:
+  - arch: x86_64
+    epoch: null
+    name: libffi
+    release: 19.el7
+    source: rpm
+    version: 3.0.13
+  libfontenc:
+  - arch: x86_64
+    epoch: null
+    name: libfontenc
+    release: 3.el7
+    source: rpm
+    version: 1.1.3
+  libgcc:
+  - arch: x86_64
+    epoch: null
+    name: libgcc
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgcrypt:
+  - arch: x86_64
+    epoch: null
+    name: libgcrypt
+    release: 14.el7
+    source: rpm
+    version: 1.5.3
+  libglvnd:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-egl:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-egl
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libglvnd-glx:
+  - arch: x86_64
+    epoch: 1
+    name: libglvnd-glx
+    release: 0.8.git5baa1e5.el7
+    source: rpm
+    version: 1.0.1
+  libgomp:
+  - arch: x86_64
+    epoch: null
+    name: libgomp
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libgpg-error:
+  - arch: x86_64
+    epoch: null
+    name: libgpg-error
+    release: 3.el7
+    source: rpm
+    version: '1.12'
+  libicu:
+  - arch: x86_64
+    epoch: null
+    name: libicu
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libicu-devel:
+  - arch: x86_64
+    epoch: null
+    name: libicu-devel
+    release: 4.el7_7
+    source: rpm
+    version: '50.2'
+  libidn:
+  - arch: x86_64
+    epoch: null
+    name: libidn
+    release: 4.el7
+    source: rpm
+    version: '1.28'
+  libini_config:
+  - arch: x86_64
+    epoch: null
+    name: libini_config
+    release: 32.el7
+    source: rpm
+    version: 1.3.1
+  libjpeg-turbo:
+  - arch: x86_64
+    epoch: null
+    name: libjpeg-turbo
+    release: 8.el7
+    source: rpm
+    version: 1.2.90
+  libmnl:
+  - arch: x86_64
+    epoch: null
+    name: libmnl
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  libmount:
+  - arch: x86_64
+    epoch: null
+    name: libmount
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libmpc:
+  - arch: x86_64
+    epoch: null
+    name: libmpc
+    release: 3.el7
+    source: rpm
+    version: 1.0.1
+  libndp:
+  - arch: x86_64
+    epoch: null
+    name: libndp
+    release: 9.el7
+    source: rpm
+    version: '1.2'
+  libnetfilter_conntrack:
+  - arch: x86_64
+    epoch: null
+    name: libnetfilter_conntrack
+    release: 1.el7_3
+    source: rpm
+    version: 1.0.6
+  libnfnetlink:
+  - arch: x86_64
+    epoch: null
+    name: libnfnetlink
+    release: 4.el7
+    source: rpm
+    version: 1.0.1
+  libnfsidmap:
+  - arch: x86_64
+    epoch: null
+    name: libnfsidmap
+    release: 19.el7
+    source: rpm
+    version: '0.25'
+  libnl3:
+  - arch: x86_64
+    epoch: null
+    name: libnl3
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libnl3-cli:
+  - arch: x86_64
+    epoch: null
+    name: libnl3-cli
+    release: 4.el7
+    source: rpm
+    version: 3.2.28
+  libpath_utils:
+  - arch: x86_64
+    epoch: null
+    name: libpath_utils
+    release: 32.el7
+    source: rpm
+    version: 0.2.1
+  libpciaccess:
+  - arch: x86_64
+    epoch: null
+    name: libpciaccess
+    release: 1.el7
+    source: rpm
+    version: '0.14'
+  libpipeline:
+  - arch: x86_64
+    epoch: null
+    name: libpipeline
+    release: 3.el7
+    source: rpm
+    version: 1.2.3
+  libpng:
+  - arch: x86_64
+    epoch: 2
+    name: libpng
+    release: 7.el7_2
+    source: rpm
+    version: 1.5.13
+  libpwquality:
+  - arch: x86_64
+    epoch: null
+    name: libpwquality
+    release: 5.el7
+    source: rpm
+    version: 1.2.3
+  libref_array:
+  - arch: x86_64
+    epoch: null
+    name: libref_array
+    release: 32.el7
+    source: rpm
+    version: 0.1.5
+  libseccomp:
+  - arch: x86_64
+    epoch: null
+    name: libseccomp
+    release: 4.el7
+    source: rpm
+    version: 2.3.1
+  libselinux:
+  - arch: x86_64
+    epoch: null
+    name: libselinux
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-python:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-python
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libselinux-utils:
+  - arch: x86_64
+    epoch: null
+    name: libselinux-utils
+    release: 15.el7
+    source: rpm
+    version: '2.5'
+  libsemanage:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsemanage-python:
+  - arch: x86_64
+    epoch: null
+    name: libsemanage-python
+    release: 14.el7
+    source: rpm
+    version: '2.5'
+  libsepol:
+  - arch: x86_64
+    epoch: null
+    name: libsepol
+    release: 10.el7
+    source: rpm
+    version: '2.5'
+  libsmartcols:
+  - arch: x86_64
+    epoch: null
+    name: libsmartcols
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libss:
+  - arch: x86_64
+    epoch: null
+    name: libss
+    release: 17.el7
+    source: rpm
+    version: 1.42.9
+  libssh2:
+  - arch: x86_64
+    epoch: null
+    name: libssh2
+    release: 3.el7
+    source: rpm
+    version: 1.8.0
+  libstdc++:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libstdc++-devel:
+  - arch: x86_64
+    epoch: null
+    name: libstdc++-devel
+    release: 44.el7
+    source: rpm
+    version: 4.8.5
+  libsysfs:
+  - arch: x86_64
+    epoch: null
+    name: libsysfs
+    release: 16.el7
+    source: rpm
+    version: 2.1.0
+  libtasn1:
+  - arch: x86_64
+    epoch: null
+    name: libtasn1
+    release: 1.el7
+    source: rpm
+    version: '4.10'
+  libteam:
+  - arch: x86_64
+    epoch: null
+    name: libteam
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  libthai:
+  - arch: x86_64
+    epoch: null
+    name: libthai
+    release: 9.el7
+    source: rpm
+    version: 0.1.14
+  libtiff:
+  - arch: x86_64
+    epoch: null
+    name: libtiff
+    release: 35.el7
+    source: rpm
+    version: 4.0.3
+  libtirpc:
+  - arch: x86_64
+    epoch: null
+    name: libtirpc
+    release: 0.16.el7
+    source: rpm
+    version: 0.2.4
+  libtool:
+  - arch: x86_64
+    epoch: null
+    name: libtool
+    release: 22.el7_3
+    source: rpm
+    version: 2.4.2
+  libunistring:
+  - arch: x86_64
+    epoch: null
+    name: libunistring
+    release: 9.el7
+    source: rpm
+    version: 0.9.3
+  libuser:
+  - arch: x86_64
+    epoch: null
+    name: libuser
+    release: 9.el7
+    source: rpm
+    version: '0.60'
+  libutempter:
+  - arch: x86_64
+    epoch: null
+    name: libutempter
+    release: 4.el7
+    source: rpm
+    version: 1.1.6
+  libuuid:
+  - arch: x86_64
+    epoch: null
+    name: libuuid
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  libverto:
+  - arch: x86_64
+    epoch: null
+    name: libverto
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libverto-libevent:
+  - arch: x86_64
+    epoch: null
+    name: libverto-libevent
+    release: 4.el7
+    source: rpm
+    version: 0.2.5
+  libwayland-client:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-client
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libwayland-server:
+  - arch: x86_64
+    epoch: null
+    name: libwayland-server
+    release: 1.el7
+    source: rpm
+    version: 1.15.0
+  libxcb:
+  - arch: x86_64
+    epoch: null
+    name: libxcb
+    release: 1.el7
+    source: rpm
+    version: '1.13'
+  libxml2:
+  - arch: x86_64
+    epoch: null
+    name: libxml2
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxml2-python:
+  - arch: x86_64
+    epoch: null
+    name: libxml2-python
+    release: 6.el7.4
+    source: rpm
+    version: 2.9.1
+  libxshmfence:
+  - arch: x86_64
+    epoch: null
+    name: libxshmfence
+    release: 1.el7
+    source: rpm
+    version: '1.2'
+  libxslt:
+  - arch: x86_64
+    epoch: null
+    name: libxslt
+    release: 6.el7
+    source: rpm
+    version: 1.1.28
+  libyaml:
+  - arch: x86_64
+    epoch: null
+    name: libyaml
+    release: 11.el7_0
+    source: rpm
+    version: 0.1.4
+  lksctp-tools:
+  - arch: x86_64
+    epoch: null
+    name: lksctp-tools
+    release: 2.el7
+    source: rpm
+    version: 1.0.17
+  llvm-toolset-7-clang:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-clang-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-clang-libs
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-compiler-rt:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-compiler-rt
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-libomp:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-libomp
+    release: 2.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-llvm-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-llvm-libs
+    release: 8.el7
+    source: rpm
+    version: 5.0.1
+  llvm-toolset-7-runtime:
+  - arch: x86_64
+    epoch: null
+    name: llvm-toolset-7-runtime
+    release: 4.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-devel:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-devel
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  llvm5.0-libs:
+  - arch: x86_64
+    epoch: null
+    name: llvm5.0-libs
+    release: 7.el7
+    source: rpm
+    version: 5.0.1
+  lm_sensors-libs:
+  - arch: x86_64
+    epoch: null
+    name: lm_sensors-libs
+    release: 8.20160601gitf9185e5.el7
+    source: rpm
+    version: 3.4.0
+  log4j:
+  - arch: noarch
+    epoch: 0
+    name: log4j
+    release: 16.el7_4
+    source: rpm
+    version: 1.2.17
+  logrotate:
+  - arch: x86_64
+    epoch: null
+    name: logrotate
+    release: 19.el7
+    source: rpm
+    version: 3.8.6
+  lshw:
+  - arch: x86_64
+    epoch: null
+    name: lshw
+    release: 14.el7
+    source: rpm
+    version: B.02.18
+  lua:
+  - arch: x86_64
+    epoch: null
+    name: lua
+    release: 15.el7
+    source: rpm
+    version: 5.1.4
+  lz4:
+  - arch: x86_64
+    epoch: null
+    name: lz4
+    release: 3.el7
+    source: rpm
+    version: 1.7.5
+  lzo:
+  - arch: x86_64
+    epoch: null
+    name: lzo
+    release: 8.el7
+    source: rpm
+    version: '2.06'
+  m4:
+  - arch: x86_64
+    epoch: null
+    name: m4
+    release: 10.el7
+    source: rpm
+    version: 1.4.16
+  mailcap:
+  - arch: noarch
+    epoch: null
+    name: mailcap
+    release: 2.el7
+    source: rpm
+    version: 2.1.41
+  make:
+  - arch: x86_64
+    epoch: 1
+    name: make
+    release: 24.el7
+    source: rpm
+    version: '3.82'
+  man-db:
+  - arch: x86_64
+    epoch: null
+    name: man-db
+    release: 11.el7
+    source: rpm
+    version: 2.6.3
+  mariadb-libs:
+  - arch: x86_64
+    epoch: 1
+    name: mariadb-libs
+    release: 1.el7
+    source: rpm
+    version: 5.5.65
+  mesa-libEGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libEGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libGL:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libGL
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libgbm:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libgbm
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  mesa-libglapi:
+  - arch: x86_64
+    epoch: null
+    name: mesa-libglapi
+    release: 12.el7_9
+    source: rpm
+    version: 18.3.4
+  microcode_ctl:
+  - arch: x86_64
+    epoch: 2
+    name: microcode_ctl
+    release: 61.el7
+    source: rpm
+    version: '2.1'
+  mozjs17:
+  - arch: x86_64
+    epoch: null
+    name: mozjs17
+    release: 20.el7
+    source: rpm
+    version: 17.0.0
+  mpfr:
+  - arch: x86_64
+    epoch: null
+    name: mpfr
+    release: 4.el7
+    source: rpm
+    version: 3.1.1
+  ncurses:
+  - arch: x86_64
+    epoch: null
+    name: ncurses
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-base:
+  - arch: noarch
+    epoch: null
+    name: ncurses-base
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-devel:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-devel
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  ncurses-libs:
+  - arch: x86_64
+    epoch: null
+    name: ncurses-libs
+    release: 14.20130511.el7_4
+    source: rpm
+    version: '5.9'
+  net-snmp-agent-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-agent-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-snmp-libs:
+  - arch: x86_64
+    epoch: 1
+    name: net-snmp-libs
+    release: 49.el7_9.1
+    source: rpm
+    version: 5.7.2
+  net-tools:
+  - arch: x86_64
+    epoch: null
+    name: net-tools
+    release: 0.25.20131004git.el7
+    source: rpm
+    version: '2.0'
+  newt:
+  - arch: x86_64
+    epoch: null
+    name: newt
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  newt-python:
+  - arch: x86_64
+    epoch: null
+    name: newt-python
+    release: 4.el7
+    source: rpm
+    version: 0.52.15
+  nfs-utils:
+  - arch: x86_64
+    epoch: 1
+    name: nfs-utils
+    release: 0.66.el7
+    source: rpm
+    version: 1.3.0
+  nginx:
+  - arch: x86_64
+    epoch: 1
+    name: nginx
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-filesystem:
+  - arch: noarch
+    epoch: 1
+    name: nginx-filesystem
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nginx-mod-stream:
+  - arch: x86_64
+    epoch: 1
+    name: nginx-mod-stream
+    release: 2.el7
+    source: rpm
+    version: 1.20.1
+  nspr:
+  - arch: x86_64
+    epoch: null
+    name: nspr
+    release: 1.el7
+    source: rpm
+    version: 4.21.0
+  nss:
+  - arch: x86_64
+    epoch: null
+    name: nss
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-pem:
+  - arch: x86_64
+    epoch: null
+    name: nss-pem
+    release: 7.el7
+    source: rpm
+    version: 1.0.3
+  nss-softokn:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-softokn-freebl:
+  - arch: x86_64
+    epoch: null
+    name: nss-softokn-freebl
+    release: 8.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-sysinit:
+  - arch: x86_64
+    epoch: null
+    name: nss-sysinit
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-tools:
+  - arch: x86_64
+    epoch: null
+    name: nss-tools
+    release: 7.el7_7
+    source: rpm
+    version: 3.44.0
+  nss-util:
+  - arch: x86_64
+    epoch: null
+    name: nss-util
+    release: 4.el7_7
+    source: rpm
+    version: 3.44.0
+  numactl-libs:
+  - arch: x86_64
+    epoch: null
+    name: numactl-libs
+    release: 5.el7
+    source: rpm
+    version: 2.0.12
+  openldap:
+  - arch: x86_64
+    epoch: null
+    name: openldap
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openldap-devel:
+  - arch: x86_64
+    epoch: null
+    name: openldap-devel
+    release: 24.el7_9
+    source: rpm
+    version: 2.4.44
+  openssh:
+  - arch: x86_64
+    epoch: null
+    name: openssh
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-clients:
+  - arch: x86_64
+    epoch: null
+    name: openssh-clients
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssh-server:
+  - arch: x86_64
+    epoch: null
+    name: openssh-server
+    release: 21.el7
+    source: rpm
+    version: 7.4p1
+  openssl:
+  - arch: x86_64
+    epoch: 1
+    name: openssl
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl-libs
+    release: 19.el7
+    source: rpm
+    version: 1.0.2k
+  openssl11-libs:
+  - arch: x86_64
+    epoch: 1
+    name: openssl11-libs
+    release: 3.el7
+    source: rpm
+    version: 1.1.1g
+  os-prober:
+  - arch: x86_64
+    epoch: null
+    name: os-prober
+    release: 9.el7
+    source: rpm
+    version: '1.58'
+  p11-kit:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  p11-kit-trust:
+  - arch: x86_64
+    epoch: null
+    name: p11-kit-trust
+    release: 3.el7
+    source: rpm
+    version: 0.23.5
+  pam:
+  - arch: x86_64
+    epoch: null
+    name: pam
+    release: 23.el7
+    source: rpm
+    version: 1.1.8
+  pango:
+  - arch: x86_64
+    epoch: null
+    name: pango
+    release: 4.el7_7
+    source: rpm
+    version: 1.42.4
+  parted:
+  - arch: x86_64
+    epoch: null
+    name: parted
+    release: 32.el7
+    source: rpm
+    version: '3.1'
+  passwd:
+  - arch: x86_64
+    epoch: null
+    name: passwd
+    release: 6.el7
+    source: rpm
+    version: '0.79'
+  pciutils-libs:
+  - arch: x86_64
+    epoch: null
+    name: pciutils-libs
+    release: 3.el7
+    source: rpm
+    version: 3.5.1
+  pcre:
+  - arch: x86_64
+    epoch: null
+    name: pcre
+    release: 17.el7
+    source: rpm
+    version: '8.32'
+  pcsc-lite-libs:
+  - arch: x86_64
+    epoch: null
+    name: pcsc-lite-libs
+    release: 8.el7
+    source: rpm
+    version: 1.8.8
+  perl:
+  - arch: x86_64
+    epoch: 4
+    name: perl
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-Carp:
+  - arch: noarch
+    epoch: null
+    name: perl-Carp
+    release: 244.el7
+    source: rpm
+    version: '1.26'
+  perl-Data-Dumper:
+  - arch: x86_64
+    epoch: null
+    name: perl-Data-Dumper
+    release: 3.el7
+    source: rpm
+    version: '2.145'
+  perl-Encode:
+  - arch: x86_64
+    epoch: null
+    name: perl-Encode
+    release: 7.el7
+    source: rpm
+    version: '2.51'
+  perl-Exporter:
+  - arch: noarch
+    epoch: null
+    name: perl-Exporter
+    release: 3.el7
+    source: rpm
+    version: '5.68'
+  perl-File-Path:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Path
+    release: 2.el7
+    source: rpm
+    version: '2.09'
+  perl-File-Temp:
+  - arch: noarch
+    epoch: null
+    name: perl-File-Temp
+    release: 3.el7
+    source: rpm
+    version: 0.23.01
+  perl-Filter:
+  - arch: x86_64
+    epoch: null
+    name: perl-Filter
+    release: 3.el7
+    source: rpm
+    version: '1.49'
+  perl-Getopt-Long:
+  - arch: noarch
+    epoch: null
+    name: perl-Getopt-Long
+    release: 3.el7
+    source: rpm
+    version: '2.40'
+  perl-HTTP-Tiny:
+  - arch: noarch
+    epoch: null
+    name: perl-HTTP-Tiny
+    release: 3.el7
+    source: rpm
+    version: '0.033'
+  perl-PathTools:
+  - arch: x86_64
+    epoch: null
+    name: perl-PathTools
+    release: 5.el7
+    source: rpm
+    version: '3.40'
+  perl-Pod-Escapes:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Escapes
+    release: 299.el7_9
+    source: rpm
+    version: '1.04'
+  perl-Pod-Perldoc:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Perldoc
+    release: 4.el7
+    source: rpm
+    version: '3.20'
+  perl-Pod-Simple:
+  - arch: noarch
+    epoch: 1
+    name: perl-Pod-Simple
+    release: 4.el7
+    source: rpm
+    version: '3.28'
+  perl-Pod-Usage:
+  - arch: noarch
+    epoch: null
+    name: perl-Pod-Usage
+    release: 3.el7
+    source: rpm
+    version: '1.63'
+  perl-Scalar-List-Utils:
+  - arch: x86_64
+    epoch: null
+    name: perl-Scalar-List-Utils
+    release: 248.el7
+    source: rpm
+    version: '1.27'
+  perl-Socket:
+  - arch: x86_64
+    epoch: null
+    name: perl-Socket
+    release: 5.el7
+    source: rpm
+    version: '2.010'
+  perl-Storable:
+  - arch: x86_64
+    epoch: null
+    name: perl-Storable
+    release: 3.el7
+    source: rpm
+    version: '2.45'
+  perl-Test-Harness:
+  - arch: noarch
+    epoch: null
+    name: perl-Test-Harness
+    release: 3.el7
+    source: rpm
+    version: '3.28'
+  perl-Text-ParseWords:
+  - arch: noarch
+    epoch: null
+    name: perl-Text-ParseWords
+    release: 4.el7
+    source: rpm
+    version: '3.29'
+  perl-Thread-Queue:
+  - arch: noarch
+    epoch: null
+    name: perl-Thread-Queue
+    release: 2.el7
+    source: rpm
+    version: '3.02'
+  perl-Time-HiRes:
+  - arch: x86_64
+    epoch: 4
+    name: perl-Time-HiRes
+    release: 3.el7
+    source: rpm
+    version: '1.9725'
+  perl-Time-Local:
+  - arch: noarch
+    epoch: null
+    name: perl-Time-Local
+    release: 2.el7
+    source: rpm
+    version: '1.2300'
+  perl-constant:
+  - arch: noarch
+    epoch: null
+    name: perl-constant
+    release: 2.el7
+    source: rpm
+    version: '1.27'
+  perl-libs:
+  - arch: x86_64
+    epoch: 4
+    name: perl-libs
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-macros:
+  - arch: x86_64
+    epoch: 4
+    name: perl-macros
+    release: 299.el7_9
+    source: rpm
+    version: 5.16.3
+  perl-parent:
+  - arch: noarch
+    epoch: 1
+    name: perl-parent
+    release: 244.el7
+    source: rpm
+    version: '0.225'
+  perl-podlators:
+  - arch: noarch
+    epoch: null
+    name: perl-podlators
+    release: 3.el7
+    source: rpm
+    version: 2.5.1
+  perl-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: perl-srpm-macros
+    release: 8.el7
+    source: rpm
+    version: '1'
+  perl-threads:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads
+    release: 4.el7
+    source: rpm
+    version: '1.87'
+  perl-threads-shared:
+  - arch: x86_64
+    epoch: null
+    name: perl-threads-shared
+    release: 6.el7
+    source: rpm
+    version: '1.43'
+  pgdg-redhat-repo:
+  - arch: noarch
+    epoch: null
+    name: pgdg-redhat-repo
+    release: '24'
+    source: rpm
+    version: '42.0'
+  pinentry:
+  - arch: x86_64
+    epoch: null
+    name: pinentry
+    release: 17.el7
+    source: rpm
+    version: 0.8.1
+  pixman:
+  - arch: x86_64
+    epoch: null
+    name: pixman
+    release: 1.el7
+    source: rpm
+    version: 0.34.0
+  pkgconfig:
+  - arch: x86_64
+    epoch: 1
+    name: pkgconfig
+    release: 4.el7
+    source: rpm
+    version: 0.27.1
+  policycoreutils:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  policycoreutils-python:
+  - arch: x86_64
+    epoch: null
+    name: policycoreutils-python
+    release: 34.el7
+    source: rpm
+    version: '2.5'
+  polkit:
+  - arch: x86_64
+    epoch: null
+    name: polkit
+    release: 26.el7
+    source: rpm
+    version: '0.112'
+  polkit-pkla-compat:
+  - arch: x86_64
+    epoch: null
+    name: polkit-pkla-compat
+    release: 4.el7
+    source: rpm
+    version: '0.1'
+  popt:
+  - arch: x86_64
+    epoch: null
+    name: popt
+    release: 16.el7
+    source: rpm
+    version: '1.13'
+  postfix:
+  - arch: x86_64
+    epoch: 2
+    name: postfix
+    release: 9.el7
+    source: rpm
+    version: 2.10.1
+  postgresql-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql-libs
+    release: 7.el7_9
+    source: rpm
+    version: 9.2.24
+  postgresql11:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-contrib:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-contrib
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-devel:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-devel
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-libs:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-libs
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  postgresql11-server:
+  - arch: x86_64
+    epoch: null
+    name: postgresql11-server
+    release: 1PGDG.rhel7
+    source: rpm
+    version: '11.15'
+  procps-ng:
+  - arch: x86_64
+    epoch: null
+    name: procps-ng
+    release: 27.el7
+    source: rpm
+    version: 3.3.10
+  pth:
+  - arch: x86_64
+    epoch: null
+    name: pth
+    release: 23.el7
+    source: rpm
+    version: 2.0.7
+  pygpgme:
+  - arch: x86_64
+    epoch: null
+    name: pygpgme
+    release: 9.el7
+    source: rpm
+    version: '0.3'
+  pyliblzma:
+  - arch: x86_64
+    epoch: null
+    name: pyliblzma
+    release: 11.el7
+    source: rpm
+    version: 0.5.3
+  pyserial:
+  - arch: noarch
+    epoch: null
+    name: pyserial
+    release: 6.el7
+    source: rpm
+    version: '2.6'
+  python:
+  - arch: x86_64
+    epoch: null
+    name: python
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-IPy:
+  - arch: noarch
+    epoch: null
+    name: python-IPy
+    release: 6.el7
+    source: rpm
+    version: '0.75'
+  python-babel:
+  - arch: noarch
+    epoch: null
+    name: python-babel
+    release: 8.el7
+    source: rpm
+    version: 0.9.6
+  python-backports:
+  - arch: x86_64
+    epoch: null
+    name: python-backports
+    release: 8.el7
+    source: rpm
+    version: '1.0'
+  python-backports-ssl_match_hostname:
+  - arch: noarch
+    epoch: null
+    name: python-backports-ssl_match_hostname
+    release: 1.el7
+    source: rpm
+    version: 3.5.0.1
+  python-chardet:
+  - arch: noarch
+    epoch: null
+    name: python-chardet
+    release: 3.el7
+    source: rpm
+    version: 2.2.1
+  python-configobj:
+  - arch: noarch
+    epoch: null
+    name: python-configobj
+    release: 7.el7
+    source: rpm
+    version: 4.7.2
+  python-decorator:
+  - arch: noarch
+    epoch: null
+    name: python-decorator
+    release: 3.el7
+    source: rpm
+    version: 3.4.0
+  python-devel:
+  - arch: x86_64
+    epoch: null
+    name: python-devel
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-gobject-base:
+  - arch: x86_64
+    epoch: null
+    name: python-gobject-base
+    release: 1.el7_4.1
+    source: rpm
+    version: 3.22.0
+  python-iniparse:
+  - arch: noarch
+    epoch: null
+    name: python-iniparse
+    release: 9.el7
+    source: rpm
+    version: '0.4'
+  python-ipaddress:
+  - arch: noarch
+    epoch: null
+    name: python-ipaddress
+    release: 2.el7
+    source: rpm
+    version: 1.0.16
+  python-javapackages:
+  - arch: noarch
+    epoch: null
+    name: python-javapackages
+    release: 11.el7
+    source: rpm
+    version: 3.4.1
+  python-jinja2:
+  - arch: noarch
+    epoch: null
+    name: python-jinja2
+    release: 4.el7
+    source: rpm
+    version: 2.7.2
+  python-jsonpatch:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpatch
+    release: 4.el7
+    source: rpm
+    version: '1.2'
+  python-jsonpointer:
+  - arch: noarch
+    epoch: null
+    name: python-jsonpointer
+    release: 2.el7
+    source: rpm
+    version: '1.9'
+  python-kitchen:
+  - arch: noarch
+    epoch: null
+    name: python-kitchen
+    release: 5.el7
+    source: rpm
+    version: 1.1.1
+  python-libs:
+  - arch: x86_64
+    epoch: null
+    name: python-libs
+    release: 90.el7
+    source: rpm
+    version: 2.7.5
+  python-linux-procfs:
+  - arch: noarch
+    epoch: null
+    name: python-linux-procfs
+    release: 4.el7
+    source: rpm
+    version: 0.4.11
+  python-lxml:
+  - arch: x86_64
+    epoch: null
+    name: python-lxml
+    release: 4.el7
+    source: rpm
+    version: 3.2.1
+  python-markupsafe:
+  - arch: x86_64
+    epoch: null
+    name: python-markupsafe
+    release: 10.el7
+    source: rpm
+    version: '0.11'
+  python-perf:
+  - arch: x86_64
+    epoch: null
+    name: python-perf
+    release: 1127.el7
+    source: rpm
+    version: 3.10.0
+  python-prettytable:
+  - arch: noarch
+    epoch: null
+    name: python-prettytable
+    release: 3.el7
+    source: rpm
+    version: 0.7.2
+  python-pycurl:
+  - arch: x86_64
+    epoch: null
+    name: python-pycurl
+    release: 19.el7
+    source: rpm
+    version: 7.19.0
+  python-pyudev:
+  - arch: noarch
+    epoch: null
+    name: python-pyudev
+    release: 9.el7
+    source: rpm
+    version: '0.15'
+  python-requests:
+  - arch: noarch
+    epoch: null
+    name: python-requests
+    release: 9.el7_8
+    source: rpm
+    version: 2.6.0
+  python-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-schedutils:
+  - arch: x86_64
+    epoch: null
+    name: python-schedutils
+    release: 6.el7
+    source: rpm
+    version: '0.4'
+  python-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python-setuptools
+    release: 7.el7
+    source: rpm
+    version: 0.9.8
+  python-six:
+  - arch: noarch
+    epoch: null
+    name: python-six
+    release: 2.el7
+    source: rpm
+    version: 1.9.0
+  python-srpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python-srpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python-urlgrabber:
+  - arch: noarch
+    epoch: null
+    name: python-urlgrabber
+    release: 10.el7
+    source: rpm
+    version: '3.10'
+  python-urllib3:
+  - arch: noarch
+    epoch: null
+    name: python-urllib3
+    release: 7.el7
+    source: rpm
+    version: 1.10.2
+  python2-pip:
+  - arch: noarch
+    epoch: null
+    name: python2-pip
+    release: 14.el7
+    source: rpm
+    version: 8.1.2
+  python2-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python2-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3:
+  - arch: x86_64
+    epoch: null
+    name: python3
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-devel:
+  - arch: x86_64
+    epoch: null
+    name: python3-devel
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-libs:
+  - arch: x86_64
+    epoch: null
+    name: python3-libs
+    release: 18.el7
+    source: rpm
+    version: 3.6.8
+  python3-pip:
+  - arch: noarch
+    epoch: null
+    name: python3-pip
+    release: 8.el7
+    source: rpm
+    version: 9.0.3
+  python3-rpm-generators:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-generators
+    release: 2.el7
+    source: rpm
+    version: '6'
+  python3-rpm-macros:
+  - arch: noarch
+    epoch: null
+    name: python3-rpm-macros
+    release: 34.el7
+    source: rpm
+    version: '3'
+  python3-setuptools:
+  - arch: noarch
+    epoch: null
+    name: python3-setuptools
+    release: 10.el7
+    source: rpm
+    version: 39.2.0
+  pyxattr:
+  - arch: x86_64
+    epoch: null
+    name: pyxattr
+    release: 5.el7
+    source: rpm
+    version: 0.5.1
+  qemu-guest-agent:
+  - arch: x86_64
+    epoch: 10
+    name: qemu-guest-agent
+    release: 3.el7
+    source: rpm
+    version: 2.12.0
+  qrencode-libs:
+  - arch: x86_64
+    epoch: null
+    name: qrencode-libs
+    release: 3.el7
+    source: rpm
+    version: 3.4.1
+  quota:
+  - arch: x86_64
+    epoch: 1
+    name: quota
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  quota-nls:
+  - arch: noarch
+    epoch: 1
+    name: quota-nls
+    release: 19.el7
+    source: rpm
+    version: '4.01'
+  readline:
+  - arch: x86_64
+    epoch: null
+    name: readline
+    release: 11.el7
+    source: rpm
+    version: '6.2'
+  redhat-rpm-config:
+  - arch: noarch
+    epoch: null
+    name: redhat-rpm-config
+    release: 88.el7.centos
+    source: rpm
+    version: 9.1.0
+  rootfiles:
+  - arch: noarch
+    epoch: null
+    name: rootfiles
+    release: 11.el7
+    source: rpm
+    version: '8.1'
+  rpcbind:
+  - arch: x86_64
+    epoch: null
+    name: rpcbind
+    release: 49.el7
+    source: rpm
+    version: 0.2.0
+  rpm:
+  - arch: x86_64
+    epoch: null
+    name: rpm
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-build-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-build-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-libs:
+  - arch: x86_64
+    epoch: null
+    name: rpm-libs
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rpm-python:
+  - arch: x86_64
+    epoch: null
+    name: rpm-python
+    release: 43.el7
+    source: rpm
+    version: 4.11.3
+  rsync:
+  - arch: x86_64
+    epoch: null
+    name: rsync
+    release: 10.el7
+    source: rpm
+    version: 3.1.2
+  rsyslog:
+  - arch: x86_64
+    epoch: null
+    name: rsyslog
+    release: 52.el7
+    source: rpm
+    version: 8.24.0
+  scl-utils:
+  - arch: x86_64
+    epoch: null
+    name: scl-utils
+    release: 19.el7
+    source: rpm
+    version: '20130529'
+  sed:
+  - arch: x86_64
+    epoch: null
+    name: sed
+    release: 6.el7
+    source: rpm
+    version: 4.2.2
+  selinux-policy:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  selinux-policy-targeted:
+  - arch: noarch
+    epoch: null
+    name: selinux-policy-targeted
+    release: 266.el7
+    source: rpm
+    version: 3.13.1
+  setools-libs:
+  - arch: x86_64
+    epoch: null
+    name: setools-libs
+    release: 4.el7
+    source: rpm
+    version: 3.3.8
+  setup:
+  - arch: noarch
+    epoch: null
+    name: setup
+    release: 11.el7
+    source: rpm
+    version: 2.8.71
+  sg3_utils:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  sg3_utils-libs:
+  - arch: x86_64
+    epoch: 1
+    name: sg3_utils-libs
+    release: 19.el7
+    source: rpm
+    version: '1.37'
+  shadow-utils:
+  - arch: x86_64
+    epoch: 2
+    name: shadow-utils
+    release: 5.el7
+    source: rpm
+    version: '4.6'
+  shared-mime-info:
+  - arch: x86_64
+    epoch: null
+    name: shared-mime-info
+    release: 5.el7
+    source: rpm
+    version: '1.8'
+  slang:
+  - arch: x86_64
+    epoch: null
+    name: slang
+    release: 11.el7
+    source: rpm
+    version: 2.2.4
+  snappy:
+  - arch: x86_64
+    epoch: null
+    name: snappy
+    release: 3.el7
+    source: rpm
+    version: 1.1.0
+  sqlite:
+  - arch: x86_64
+    epoch: null
+    name: sqlite
+    release: 8.el7_7.1
+    source: rpm
+    version: 3.7.17
+  sudo:
+  - arch: x86_64
+    epoch: null
+    name: sudo
+    release: 9.el7
+    source: rpm
+    version: 1.8.23
+  systemd:
+  - arch: x86_64
+    epoch: null
+    name: systemd
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-libs:
+  - arch: x86_64
+    epoch: null
+    name: systemd-libs
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  systemd-sysv:
+  - arch: x86_64
+    epoch: null
+    name: systemd-sysv
+    release: 73.el7_8.5
+    source: rpm
+    version: '219'
+  sysvinit-tools:
+  - arch: x86_64
+    epoch: null
+    name: sysvinit-tools
+    release: 14.dsf.el7
+    source: rpm
+    version: '2.88'
+  tar:
+  - arch: x86_64
+    epoch: 2
+    name: tar
+    release: 35.el7
+    source: rpm
+    version: '1.26'
+  tcp_wrappers:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  tcp_wrappers-libs:
+  - arch: x86_64
+    epoch: null
+    name: tcp_wrappers-libs
+    release: 77.el7
+    source: rpm
+    version: '7.6'
+  teamd:
+  - arch: x86_64
+    epoch: null
+    name: teamd
+    release: 1.el7
+    source: rpm
+    version: '1.29'
+  tomcat:
+  - arch: noarch
+    epoch: 0
+    name: tomcat
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-admin-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-admin-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-el-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-el-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-jsp-2.2-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-jsp-2.2-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-lib:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-lib
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-servlet-3.0-api:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-servlet-3.0-api
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  tomcat-webapps:
+  - arch: noarch
+    epoch: 0
+    name: tomcat-webapps
+    release: 16.el7_9
+    source: rpm
+    version: 7.0.76
+  ttmkfdir:
+  - arch: x86_64
+    epoch: null
+    name: ttmkfdir
+    release: 42.el7
+    source: rpm
+    version: 3.0.9
+  tuned:
+  - arch: noarch
+    epoch: null
+    name: tuned
+    release: 8.el7
+    source: rpm
+    version: 2.11.0
+  tzdata:
+  - arch: noarch
+    epoch: null
+    name: tzdata
+    release: 1.el7
+    source: rpm
+    version: 2019c
+  tzdata-java:
+  - arch: noarch
+    epoch: null
+    name: tzdata-java
+    release: 1.el7
+    source: rpm
+    version: 2021a
+  ustr:
+  - arch: x86_64
+    epoch: null
+    name: ustr
+    release: 16.el7
+    source: rpm
+    version: 1.0.4
+  util-linux:
+  - arch: x86_64
+    epoch: null
+    name: util-linux
+    release: 63.el7
+    source: rpm
+    version: 2.23.2
+  vim-minimal:
+  - arch: x86_64
+    epoch: 2
+    name: vim-minimal
+    release: 6.el7
+    source: rpm
+    version: 7.4.629
+  virt-what:
+  - arch: x86_64
+    epoch: null
+    name: virt-what
+    release: 4.el7
+    source: rpm
+    version: '1.18'
+  wget:
+  - arch: x86_64
+    epoch: null
+    name: wget
+    release: 18.el7_6.1
+    source: rpm
+    version: '1.14'
+  which:
+  - arch: x86_64
+    epoch: null
+    name: which
+    release: 7.el7
+    source: rpm
+    version: '2.20'
+  wpa_supplicant:
+  - arch: x86_64
+    epoch: 1
+    name: wpa_supplicant
+    release: 12.el7
+    source: rpm
+    version: '2.6'
+  xalan-j2:
+  - arch: noarch
+    epoch: 0
+    name: xalan-j2
+    release: 23.el7
+    source: rpm
+    version: 2.7.1
+  xerces-j2:
+  - arch: noarch
+    epoch: null
+    name: xerces-j2
+    release: 17.el7_0
+    source: rpm
+    version: 2.11.0
+  xfsprogs:
+  - arch: x86_64
+    epoch: null
+    name: xfsprogs
+    release: 20.el7
+    source: rpm
+    version: 4.5.0
+  xml-commons-apis:
+  - arch: noarch
+    epoch: null
+    name: xml-commons-apis
+    release: 16.el7
+    source: rpm
+    version: 1.4.01
+  xml-commons-resolver:
+  - arch: noarch
+    epoch: 0
+    name: xml-commons-resolver
+    release: 15.el7
+    source: rpm
+    version: '1.2'
+  xorg-x11-font-utils:
+  - arch: x86_64
+    epoch: 1
+    name: xorg-x11-font-utils
+    release: 21.el7
+    source: rpm
+    version: '7.5'
+  xorg-x11-fonts-Type1:
+  - arch: noarch
+    epoch: null
+    name: xorg-x11-fonts-Type1
+    release: 9.el7
+    source: rpm
+    version: '7.5'
+  xz:
+  - arch: x86_64
+    epoch: null
+    name: xz
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  xz-libs:
+  - arch: x86_64
+    epoch: null
+    name: xz-libs
+    release: 1.el7
+    source: rpm
+    version: 5.2.2
+  yum:
+  - arch: noarch
+    epoch: null
+    name: yum
+    release: 167.el7.centos
+    source: rpm
+    version: 3.4.3
+  yum-metadata-parser:
+  - arch: x86_64
+    epoch: null
+    name: yum-metadata-parser
+    release: 10.el7
+    source: rpm
+    version: 1.1.4
+  yum-plugin-fastestmirror:
+  - arch: noarch
+    epoch: null
+    name: yum-plugin-fastestmirror
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  yum-utils:
+  - arch: noarch
+    epoch: null
+    name: yum-utils
+    release: 53.el7
+    source: rpm
+    version: 1.1.31
+  zip:
+  - arch: x86_64
+    epoch: null
+    name: zip
+    release: 11.el7
+    source: rpm
+    version: '3.0'
+  zlib:
+  - arch: x86_64
+    epoch: null
+    name: zlib
+    release: 18.el7
+    source: rpm
+    version: 1.2.7
+processes:
+- cmdline: /usr/lib/systemd/systemd --switched-root --system --deserialize 21
+  cwd: /usr/lib/systemd/
+  pid: '1'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2'
+  ppid: '0'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '6'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '7'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '8'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '9'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '10'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '11'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '12'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '13'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '14'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '16'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '18'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '19'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '20'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '21'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '22'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '23'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '24'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '25'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '26'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '27'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '28'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '29'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '36'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '37'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '38'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '39'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '47'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '49'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '50'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '51'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '52'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '65'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '116'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '197'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '198'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '268'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '274'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '275'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '276'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '277'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '279'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '290'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '291'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '292'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '293'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '294'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '295'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '296'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '297'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '298'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '299'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '300'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-journald
+  cwd: /usr/lib/systemd/
+  pid: '412'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-udevd
+  cwd: /usr/lib/systemd/
+  pid: '444'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/auditd
+  cwd: /sbin/
+  pid: '466'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '469'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/irqbalance --foreground
+  cwd: /usr/sbin/
+  pid: '511'
+  ppid: '1'
+  user: root
+- cmdline: '/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile
+    --systemd-activation'
+  cwd: /usr/bin/
+  pid: '513'
+  ppid: '1'
+  user: dbus
+- cmdline: ''
+  cwd: /
+  pid: '514'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '556'
+  ppid: '2'
+  user: root
+- cmdline: /usr/sbin/gssproxy -D
+  cwd: /usr/sbin/
+  pid: '559'
+  ppid: '1'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '564'
+  ppid: '2'
+  user: root
+- cmdline: /usr/lib/systemd/systemd-logind
+  cwd: /usr/lib/systemd/
+  pid: '566'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/polkit-1/polkitd --no-debug
+  cwd: /usr/lib/polkit-1/
+  pid: '567'
+  ppid: '1'
+  user: polkitd
+- cmdline: /usr/sbin/chronyd
+  cwd: /usr/sbin/
+  pid: '581'
+  ppid: '1'
+  user: chrony
+- cmdline: /sbin/rpcbind -w
+  cwd: /sbin/
+  pid: '582'
+  ppid: '1'
+  user: rpc
+- cmdline: /sbin/dhclient -1 -q -lf /var/lib/dhclient/dhclient--eth0.lease -pf /var/run/dhclient-eth0.pid
+    -H loadbalancer-2 eth0
+  cwd: /sbin/
+  pid: '830'
+  ppid: '1'
+  user: root
+- cmdline: /usr/lib/jvm/jre/bin/java -Djavax.sql.DataSource.Factory=org.apache.commons.dbcp.BasicDataSourceFactory
+    -classpath /usr/share/tomcat/bin/bootstrap.jar:/usr/share/tomcat/bin/tomcat-juli.jar:/usr/share/java/commons-daemon.jar
+    -Dcatalina.base=/usr/share/tomcat -Dcatalina.home=/usr/share/tomcat -Djava.endorsed.dirs=
+    -Djava.io.tmpdir=/var/cache/tomcat/temp -Djava.util.logging.config.file=/usr/share/tomcat/conf/logging.properties
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager org.apache.catalina.startup.Bootstrap
+    start
+  cwd: /usr/lib/jvm/jre/bin/
+  pid: '887'
+  ppid: '1'
+  user: tomcat
+- cmdline: /usr/bin/python2 -Es /usr/sbin/tuned -l -P
+  cwd: /usr/bin/
+  pid: '888'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '889'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy-systemd-wrapper -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid
+  cwd: /usr/sbin/
+  pid: '891'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '896'
+  ppid: '891'
+  user: haproxy
+- cmdline: /usr/sbin/haproxy -f /etc/haproxy/haproxy.cfg -p /run/haproxy.pid -Ds
+  cwd: /usr/sbin/
+  pid: '905'
+  ppid: '896'
+  user: haproxy
+- cmdline: /usr/libexec/postfix/master -w
+  cwd: /usr/libexec/postfix/
+  pid: '1074'
+  ppid: '1'
+  user: root
+- cmdline: qmgr -l -t unix -u
+  cwd: /
+  pid: '1077'
+  ppid: '1074'
+  user: postfix
+- cmdline: /usr/sbin/sshd -D
+  cwd: /usr/sbin/
+  pid: '1079'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/rsyslogd -n
+  cwd: /usr/sbin/
+  pid: '1083'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --noclear tty1 linux
+  cwd: /sbin/
+  pid: '1089'
+  ppid: '1'
+  user: root
+- cmdline: /sbin/agetty --keep-baud 115200,38400,9600 ttyS0 vt220
+  cwd: /sbin/
+  pid: '1090'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/crond -n
+  cwd: /usr/sbin/
+  pid: '1092'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: master process /usr/sbin/nginx'
+  cwd: /
+  pid: '1151'
+  ppid: '1'
+  user: root
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1156'
+  ppid: '1151'
+  user: nginx
+- cmdline: 'nginx: worker process'
+  cwd: /
+  pid: '1157'
+  ppid: '1151'
+  user: nginx
+- cmdline: ''
+  cwd: /
+  pid: '2129'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '2661'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4117'
+  ppid: '2'
+  user: root
+- cmdline: pickup -l -t unix -u
+  cwd: /
+  pid: '4171'
+  ppid: '1074'
+  user: postfix
+- cmdline: ''
+  cwd: /
+  pid: '4175'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4188'
+  ppid: '2'
+  user: root
+- cmdline: ''
+  cwd: /
+  pid: '4973'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '5659'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/1'
+  cwd: /
+  pid: '5661'
+  ppid: '5659'
+  user: centos
+- cmdline: /bin/sh -c sudo -H -S -n  -u root /bin/sh -c 'echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py'
+    && sleep 0
+  cwd: /bin/
+  pid: '5810'
+  ppid: '5661'
+  user: centos
+- cmdline: sudo -H -S -n -u root /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob
+    ; /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /
+  pid: '5823'
+  ppid: '5810'
+  user: root
+- cmdline: /bin/sh -c echo BECOME-SUCCESS-rgltwuazpjfexbnaxnpeyhpbxdhxxwob ; /usr/bin/python
+    /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /bin/
+  pid: '5824'
+  ppid: '5823'
+  user: root
+- cmdline: /usr/bin/python /home/centos/.ansible/tmp/ansible-tmp-1655414154.129737-96159-190042255695723/AnsiballZ_process_facts.py
+  cwd: /usr/bin/
+  pid: '5825'
+  ppid: '5824'
+  user: root
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15591'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15593'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15594'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15595'
+  ppid: '889'
+  user: apache
+- cmdline: /usr/sbin/httpd -DFOREGROUND
+  cwd: /usr/sbin/
+  pid: '15596'
+  ppid: '889'
+  user: apache
+- cmdline: ''
+  cwd: /
+  pid: '16751'
+  ppid: '2'
+  user: root
+- cmdline: 'sshd: centos [priv]'
+  cwd: /
+  pid: '19692'
+  ppid: '1079'
+  user: root
+- cmdline: 'sshd: centos@pts/0'
+  cwd: /
+  pid: '19694'
+  ppid: '19692'
+  user: centos
+- cmdline: -bash
+  cwd: /
+  pid: '19695'
+  ppid: '19694'
+  user: centos
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20808'
+  ppid: '1'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20809'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/sbin/keepalived -D
+  cwd: /usr/sbin/
+  pid: '20810'
+  ppid: '20808'
+  user: root
+- cmdline: /usr/pgsql-11/bin/postmaster -D /var/lib/pgsql/11/data/
+  cwd: /usr/pgsql-11/bin/
+  pid: '21221'
+  ppid: '1'
+  user: postgres
+- cmdline: 'postgres: logger'
+  cwd: /
+  pid: '21223'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: checkpointer'
+  cwd: /
+  pid: '21225'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: background writer'
+  cwd: /
+  pid: '21226'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: walwriter'
+  cwd: /
+  pid: '21227'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: autovacuum launcher'
+  cwd: /
+  pid: '21228'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: stats collector'
+  cwd: /
+  pid: '21229'
+  ppid: '21221'
+  user: postgres
+- cmdline: 'postgres: logical replication launcher'
+  cwd: /
+  pid: '21230'
+  ppid: '21221'
+  user: postgres
+- cmdline: ''
+  cwd: /
+  pid: '27662'
+  ppid: '2'
+  user: root
+software_list:
+- cmd_regexp: haproxy .*
+  custom_tasks:
+  - include_tasks:
+      file: << software_discovery__custom_tasks_definition_files_path >>/haproxy.yaml
+    name: Include HAProxy specific plugins
+  name: HAProxy
+  pkg_regexp: haproxy
+  process_type: parent
+  return_children: true
+  return_packages: true
+  vars:
+    ignore_udp: True
+tcp_listen:
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: 'nginx:'
+  pid: 1151
+  port: 82
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 83
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: 127.0.0.1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 0.0.0.0
+  name: haproxy
+  pid: 905
+  port: 5000
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: tcp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: java
+  pid: 887
+  port: 8080
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: httpd
+  pid: 889
+  port: 80
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: '::'
+  name: 'nginx:'
+  pid: 1151
+  port: 81
+  protocol: tcp
+  stime: Wed Apr 27 08:37:54 2022
+  user: root
+- address: '::'
+  name: sshd
+  pid: 1079
+  port: 22
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: ::1
+  name: postmaster
+  pid: 21221
+  port: 5432
+  protocol: tcp
+  stime: Thu Apr 28 13:53:52 2022
+  user: postgres
+- address: ::1
+  name: master
+  pid: 1074
+  port: 25
+  protocol: tcp
+  stime: Wed Apr 27 08:37:53 2022
+  user: root
+- address: 127.0.0.1
+  name: java
+  pid: 887
+  port: 8005
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+- address: '::'
+  name: java
+  pid: 887
+  port: 8009
+  protocol: tcp
+  stime: Wed Apr 27 08:37:52 2022
+  user: tomcat
+udp_listen:
+- address: 0.0.0.0
+  name: dhclient
+  pid: 830
+  port: 68
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: root
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: 127.0.0.1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: 0.0.0.0
+  name: haproxy
+  pid: 896
+  port: 49899
+  protocol: udp
+  stime: Wed Apr 27 08:37:52 2022
+  user: haproxy
+- address: 0.0.0.0
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 111
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc
+- address: ::1
+  name: chronyd
+  pid: 581
+  port: 323
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: chrony
+- address: '::'
+  name: rpcbind
+  pid: 582
+  port: 750
+  protocol: udp
+  stime: Wed Apr 27 08:37:48 2022
+  user: rpc


### PR DESCRIPTION
This PR adds the following features:

- Improve `HAProxy` software discovery with the new flag `haproxy_ignore_udp`, which ignores UDP bindings and ports.