### PR TITLE
fix: collection.ansible pinned to specific version range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.14.2
+
+## Fixed
+
+- The Ansible collection.windows is pinned to a specific version range to avoid incompatibilities introduced in version 3.0.0.
+
 # 1.14.1
 
 ## Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -43,7 +43,7 @@ tags:
 # range specifiers can be set and are separated by ','
 dependencies:
   community.general: "*"
-  community.windows: ">=1.10.0"
+  community.windows: ">=1.10.0,<3.0.0"
 
 # The URL of the originating SCM repository
 repository: https://github.com/datadope-io/ansible_collection_discovery


### PR DESCRIPTION
The Ansible collection.windows is pinned to a specific version range to avoid incompatibilities introduced in version 3.0.0.