### PR TITLE
fix: avoid evaluating the null type as a var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.15.2
+
+## Fixed
+
+- Avoid evaluating the null type as a var.
+
 # 1.15.1
 
 - Improve `snmp_facts` module to handle more edge cases.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.15.1
+version: 1.15.2
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/software_discovery/files/tasks_definitions/jboss.yaml
+++ b/roles/software_discovery/files/tasks_definitions/jboss.yaml
@@ -10,7 +10,7 @@
         loop_var: __regex__
     - name: Define default value if no match is found
       set_instance_fact:
-        "<< __entry__.key >>": null
+        "<< __entry__.key >>": "{{ None }}"
       when: __entry__.key not in __instance__
   loop: >
     << {
@@ -40,14 +40,14 @@
     extra_data: "<< __instance__.extra_data | default({}) | combine(
       {'heap_initial_allocation_memory': __instance__._heap_initial_allocation_memory}
     )>>"
-  when: __instance__._heap_initial_allocation_memory != None
+  when: __instance__._heap_initial_allocation_memory != None and __instance__._heap_initial_allocation_memory != ""
 
 - name: Save heap max memory
   set_instance_fact:
     extra_data: "<< __instance__.extra_data | default({}) | combine(
       {'heap_max_memory': __instance__._heap_max_memory}
     ) >>"
-  when: __instance__._heap_max_memory != None
+  when: __instance__._heap_max_memory != None and __instance__._heap_max_memory != ""
 
 #todo comprobar si lo que devuelve es una ruta completa o solo la ubicación de los logs
 - name: Save domain logs dir
@@ -55,32 +55,32 @@
     path: '<<__instance__._domain_log_dir>>'
     type: 'log'
     subtype: 'domain_logging_dir'
-  when: __instance__._domain_log_dir != None
+  when: __instance__._domain_log_dir != None and __instance__._domain_log_dir != ""
 
 - name: Save domain logs dir
   add_file_info:
     path: '<<__instance__._log_dir>>'
     type: 'log'
     subtype: 'logging_dir'
-  when: __instance__._log_dir != None
+  when: __instance__._log_dir != None and __instance__._log_dir != ""
 
 - name: Redefine server_name if necessary
   set_instance_fact:
     _server:
       name: "<< __instance__._server_name >>"
-  when: __instance__._server_name != None
+  when: __instance__._server_name != None and __instance__._server_name != ""
 
 - name: Save binding address
   add_binding_info:
     address: '<<__instance__._bind_address>>'
     class: 'bind_address'
-  when: __instance__._bind_address != None
+  when: __instance__._bind_address != None and __instance__._bind_address != ""
 
 - name: Save binding address management
   add_binding_info:
     address: '<<__instance__._bind_address_management>>'
     class: 'bind_address_management'
-  when: __instance__._bind_address_management != None
+  when: __instance__._bind_address_management != None and __instance__._bind_address_management != ""
 
 - name: Check instance running mode
   block:
@@ -237,7 +237,7 @@
     - name: Set standalone_xml_file if config_file is defined
       set_instance_fact:
         _standalone_xml_file: "<< (__instance__._base_dir, 'configuration', __instance__._config_file) | datadope.discovery.path_join >>"
-      when: __instance__._config_file != None
+      when: __instance__._config_file != None and __instance__._config_file != ""
     - name: Set standalone_xml_file if _config_file is undefined
       set_instance_fact:
         _standalone_xml_file: "<< (__instance__._base_dir, 'configuration/standalone.xml') | datadope.discovery.path_join >>"
@@ -544,21 +544,21 @@
     path: '<<__instance__._base_dir>>'
     type: 'data'
     subtype: 'base_dir'
-  when: __instance__._base_dir != None
+  when: __instance__._base_dir != None and __instance__._base_dir != ""
 
 - name: Save home dir
   add_file_info:
     path: '<<__instance__._home_dir>>'
     type: 'data'
     subtype: 'home_dir'
-  when: __instance__._home_dir != None
+  when: __instance__._home_dir != None and __instance__._home_dir != ""
 
 - name: Save config file
   add_file_info:
     path: '<<__instance__._config_file>>'
     type: 'config'
     subtype: 'config_file'
-  when: __instance__._config_file != None
+  when: __instance__._config_file != None and __instance__._config_file != ""
 
 - name: Save standole xml file
   add_file_info:

--- a/roles/software_discovery/files/tasks_definitions/weblogic.yaml
+++ b/roles/software_discovery/files/tasks_definitions/weblogic.yaml
@@ -10,7 +10,7 @@
     - name: Define default value if no match is found
       set_instance_fact:
         extra_data: "<< __instance__.extra_data | default({}) | combine(
-          { __entry__.key : null }
+          { __entry__.key : None }
         )>>"
       when: __entry__.key not in __instance__.extra_data | default({})
   loop: >
@@ -35,6 +35,7 @@
       when:
         - __instance__.extra_data.home is defined
         - __instance__.extra_data.home is not none
+        - __instance__.extra_data.home != ""
 
     - name: Get version from wls_home
       set_instance_fact:
@@ -43,6 +44,7 @@
       when:
         - __instance__.extra_data.wls_home is defined
         - __instance__.extra_data.wls_home is not none
+        - __instance__.extra_data.wls_home != ""
         - __instance__._file_version is not defined
 
     - name: Store version from file
@@ -54,8 +56,10 @@
   when:
     - __instance__.extra_data.home is defined
     - __instance__.extra_data.home is not none
+    - __instance__.extra_data.home != ""
     - __instance__.extra_data.wls_home is defined
     - __instance__.extra_data.wls_home is not none
+    - __instance__.extra_data.wls_home != ""
 
 - name: Remove temporary vars
   del_instance_fact:


### PR DESCRIPTION
The update replaces null with None, ensuring the value is treated as a proper Python None within Jinja2 templating. This aligns better with Ansible’s internal data handling and avoids unexpected behavior when merging dictionaries or evaluating conditions.

Details:

- Ansible OSFacts error:

`TASK [datadope.discovery.software_discovery : Execute discovery] ***************
task path: /runner/requirements_collections/ansible_collections/datadope/discovery/roles/software_discovery/tasks/main.yml:58
fatal: [host01]: FAILED! => {
    "msg": "'null' is undefined"
}`

- Ansible Trace:
`<host01> Including plugins from /runner/requirements_collections/ansible_collections/datadope/discovery/roles/software_discovery/files/tasks_definitions/weblogic.yaml
...
<host01> Executing plugin 'set_instance_fact' for task 'Extract entry regex' in block 'Gather basic configuration'
<host01> Executing plugin 'set_instance_fact' for task 'Define default value if no match is found' in block 'Gather basic configuration'
<host01> FAILING BLOCK 'Gather basic configuration': Error for plugin 'set_instance_fact' for task 'Define default value if no match is found': 'null' is undefined
...
<host01> FAILING: Error for plugin 'include_tasks' for task 'Include WebLogic specific plugins': 'null' is undefine`