### PR TITLE
fix: typo in the TCP socket assignment for SAP CCMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.15.3
+
+## Fixed
+
+- Typo in the SAP CCMS port assignment.
+
 # 1.15.2
 
 ## Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: datadope
 name: discovery
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.15.2
+version: 1.15.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/software_discovery/files/tasks_definitions/sap_ccms.yaml
+++ b/roles/software_discovery/files/tasks_definitions/sap_ccms.yaml
@@ -41,7 +41,7 @@
           - name: Check http or https
             run_module:
               check_connection:
-                address: "<< ((__port__.address == '0.0.0.0') | ternary('127.0.0.1', __item__.address)) >>"
+                address: "<< ((__port__.address == '0.0.0.0') | ternary('127.0.0.1', __port__.address)) >>"
                 port: "<< __port__.port >>"
             register: response
           - name: Set icman type


### PR DESCRIPTION
When a TCP socket is discovered and it is not equal to "0.0.0.0", the value of the variable "__item__.address" is obtained, and that variable may not contain any information about the TCP socket.